### PR TITLE
Fix deep link UID

### DIFF
--- a/app/src/main/java/com/flowfoundation/wallet/manager/walletconnect/WalletConnectResponse.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/manager/walletconnect/WalletConnectResponse.kt
@@ -49,7 +49,7 @@ private fun authn(address: String, keyId: Int): String {
     return """
 {
     "f_type": "Service",
-    "uid": "https://link.lilico.app/wc",
+    "uid": "https://frw-link.lilico.app/wc",
     "provider": {
         "f_type": "ServiceProvider",
         "f_vsn": "1.0.0",
@@ -75,7 +75,7 @@ private fun authz(address: String, keyId: Int): String {
 {
     "f_type": "Service",
     "method": "WC/RPC",
-    "uid": "https://link.lilico.app/wc",
+    "uid": "https://frw-link.lilico.app/wc",
     "f_vsn": "1.0.0",
     "endpoint": "flow_authz",
     "type": "authz",
@@ -89,7 +89,7 @@ private fun userSign(address: String, keyId: Int): String {
 {
     "f_type": "Service",
     "method": "WC/RPC",
-    "uid": "https://link.lilico.app/wc",
+    "uid": "https://frw-link.lilico.app/wc",
     "f_vsn": "1.0.0",
     "endpoint": "flow_user_sign",
     "type": "user-signature",
@@ -104,7 +104,7 @@ private fun preAuthz(): String {
     "f_type": "Service",
     "f_vsn": "1.0.0",
     "type": "pre-authz",
-    "uid": "https://link.lilico.app/wc",
+    "uid": "https://frw-link.lilico.app/wc",
     "endpoint": "flow_pre_authz",
     "method": "WC/RPC",
     "data": {
@@ -132,7 +132,7 @@ private fun accountProof(
         "f_type": "Service",
         "f_vsn": "1.0.0",
         "type": "account-proof",
-        "uid": "https://link.lilico.app/wc",
+        "uid": "https://frw-link.lilico.app/wc",
         "endpoint": "${WalletConnectMethod.ACCOUNT_PROOF.value}",
         "method": "WC/RPC",
         "data": {
@@ -160,7 +160,7 @@ private fun signMessage(): String {
         "f_type": "Service",
         "f_vsn": "1.0.0",
         "type": "user-signature",
-        "uid": "https://link.lilico.app/wc",
+        "uid": "https://frw-link.lilico.app/wc",
         "endpoint": "${WalletConnectMethod.USER_SIGNATURE.value}",
         "method": "WC/RPC"
     }


### PR DESCRIPTION
Currently, the deep link UIDs do not correspond with a valid app link.  I've corrected this to align with what I'm aware to be the latest link (https://frw-link.lilico.app/wc), but LMK if it should be something different.