### PR TITLE
fix: send available mount with gas fee free

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ android.injected.testOnly=false
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
-vCode=223
-vName=i.7.7
+vCode=224
+vName=i.7.8


### PR DESCRIPTION
## Related Issue
Closes #425 
## Summary of Changes
We are already using the available balance, so if the user has enabled gas fee free, the minimum balance should be 0.

## Need Regression Testing
<!-- Indicate whether this PR requires regression testing and why. -->
- [x] Yes
- [ ] No

## Risk Assessment
<!-- Assess the risk level of this PR:
- Low: Minimal impact, straightforward changes.
- Medium: Potential for some edge cases or indirect effects.
- High: Could affect critical functionality or many users.
-->
- [ ] Low
- [x] Medium
- [ ] High

## Additional Notes
<!-- Add any other context or comments about the PR here -->

## Screenshots (if applicable)
<!-- Attach any screenshots that help explain your changes -->
