### PR TITLE
Key store migration

### DIFF
--- a/app/src/androidTest/java/com/flowfoundation/wallet/manager/key/KeyCompatibilityManagerSimpleTest.kt
+++ b/app/src/androidTest/java/com/flowfoundation/wallet/manager/key/KeyCompatibilityManagerSimpleTest.kt
@@ -1,0 +1,231 @@
+package com.flowfoundation.wallet.manager.key
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.flow.wallet.keys.PrivateKey
+import com.flow.wallet.storage.FileSystemStorage
+import com.flow.wallet.storage.StorageProtocol
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.onflow.flow.models.SigningAlgorithm
+import java.io.File
+import java.security.KeyPairGenerator
+import java.security.KeyStore
+import java.security.spec.ECGenParameterSpec
+import java.util.*
+
+/**
+ * Simple instrumented tests for KeyCompatibilityManager without mocking.
+ * 
+ * These tests verify the actual key extraction, conversion, and storage operations
+ * using real Android Keystore and Flow-Wallet-Kit storage.
+ */
+@RunWith(AndroidJUnit4::class)
+class KeyCompatibilityManagerSimpleTest {
+
+    private lateinit var context: Context
+    private lateinit var storage: StorageProtocol
+    private val testPrefix = "simple_${UUID.randomUUID().toString().take(8)}"
+    private val oldKeystoreAlias = "user_keystore_$testPrefix"
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        val testDir = File(context.filesDir, "test_simple_${UUID.randomUUID()}")
+        storage = FileSystemStorage(testDir)
+        
+        // Clean up any existing test keys
+        cleanupTestKeys()
+    }
+
+    @After
+    fun tearDown() {
+        cleanupTestKeys()
+    }
+
+    private fun cleanupTestKeys() {
+        try {
+            // Clean up Android Keystore
+            val keyStore = KeyStore.getInstance("AndroidKeyStore")
+            keyStore.load(null)
+            if (keyStore.containsAlias(oldKeystoreAlias)) {
+                keyStore.deleteEntry(oldKeystoreAlias)
+            }
+        } catch (e: Exception) {
+            // Cleanup failed, but don't fail the test
+        }
+    }
+
+    @Test
+    fun testGetPrivateKeyWithFallback_NewStorageExists() = runBlocking {
+        // Arrange - Create a key in new storage
+        val newKeyId = "prefix_key_$testPrefix"
+        val privateKey = PrivateKey.create(storage)
+        privateKey.store(newKeyId, testPrefix)
+
+        // Act
+        val result = KeyCompatibilityManager.getPrivateKeyWithFallback(testPrefix, storage)
+
+        // Assert
+        assertNotNull("Should return private key from new storage", result)
+        
+        // Verify the key works by generating a public key
+        val publicKey = result!!.publicKey(SigningAlgorithm.ECDSA_P256)
+        assertNotNull("Should be able to generate public key", publicKey)
+        if (publicKey != null) {
+            // EC public keys can be 64 bytes (compressed) or 65 bytes (uncompressed)
+            assertTrue("Public key should be 64 or 65 bytes", publicKey.size == 64 || publicKey.size == 65)
+        }
+    }
+
+    @Test
+    fun testGetPrivateKeyWithFallback_FallbackToOldKeystore() = runBlocking {
+        // Arrange - Create a key in Android Keystore using the old pattern
+        createTestKeyInAndroidKeystore()
+
+        // Verify no key exists in new storage
+        val newKeyId = "prefix_key_$testPrefix"
+        var newStorageHasKey = false
+        try {
+            PrivateKey.get(newKeyId, testPrefix, storage)
+            newStorageHasKey = true
+        } catch (e: Exception) {
+            // Expected - no key in new storage
+        }
+        assertFalse("New storage should not have key", newStorageHasKey)
+
+        // Act
+        val result = KeyCompatibilityManager.getPrivateKeyWithFallback(testPrefix, storage)
+
+        // Assert - Modern AndroidKeyStore keys are hardware-backed and cannot be extracted
+        // This is expected behavior for security reasons
+        assertNull("Hardware-backed AndroidKeyStore keys cannot be extracted (expected)", result)
+        
+        // But we should still be able to detect that the key exists in the old keystore
+        val keyExists = KeyCompatibilityManager.hasPrivateKey(testPrefix, storage)
+        assertTrue("Should detect that key exists in old Android Keystore", keyExists)
+    }
+
+    @Test
+    fun testGetPrivateKeyWithFallback_NoKeyExists() {
+        // Arrange - Ensure no keys exist anywhere
+        cleanupTestKeys()
+
+        // Act
+        val result = KeyCompatibilityManager.getPrivateKeyWithFallback(testPrefix, storage)
+
+        // Assert
+        assertNull("Should return null when no key exists in either storage", result)
+    }
+
+    @Test
+    fun testHasPrivateKey_NewStorageExists() = runBlocking {
+        // Arrange - Create a key in new storage
+        val newKeyId = "prefix_key_$testPrefix"
+        val privateKey = PrivateKey.create(storage)
+        privateKey.store(newKeyId, testPrefix)
+
+        // Act
+        val result = KeyCompatibilityManager.hasPrivateKey(testPrefix, storage)
+
+        // Assert
+        assertTrue("Should return true when key exists in new storage", result)
+    }
+
+    @Test
+    fun testHasPrivateKey_OldKeystoreExists() {
+        // Arrange - Create a key in Android Keystore using the old pattern
+        createTestKeyInAndroidKeystore()
+
+        // Act
+        val result = KeyCompatibilityManager.hasPrivateKey(testPrefix, storage)
+
+        // Assert
+        assertTrue("Should return true when key exists in old Android Keystore", result)
+    }
+
+    @Test
+    fun testHasPrivateKey_NoKeyExists() {
+        // Arrange - Ensure no keys exist anywhere
+        cleanupTestKeys()
+
+        // Act
+        val result = KeyCompatibilityManager.hasPrivateKey(testPrefix, storage)
+
+        // Assert
+        assertFalse("Should return false when no key exists in either storage", result)
+    }
+
+    @Test
+    fun testDiagnoseKeyStorage() = runBlocking {
+        // Arrange - Create key in Android Keystore
+        createTestKeyInAndroidKeystore()
+
+        // Act
+        val report = KeyCompatibilityManager.diagnoseKeyStorage(testPrefix, storage)
+
+        // Assert
+        assertTrue("Should mention new storage", report.contains("New storage"))
+        assertTrue("Should mention old Android Keystore", report.contains("Old Android Keystore"))
+        assertTrue("Should contain test prefix", report.contains(testPrefix))
+    }
+
+    @Test
+    fun testHardwareBachedKeyLimitation() {
+        // Arrange - Create a real EC key in Android Keystore (hardware-backed)
+        createTestKeyInAndroidKeystore()
+
+        // Act - Attempt to extract and convert the key
+        val result = KeyCompatibilityManager.getPrivateKeyWithFallback(testPrefix, storage)
+
+        // Assert - Hardware-backed keys cannot be extracted (this is expected)
+        assertNull("Hardware-backed AndroidKeyStore keys cannot be extracted for security", result)
+        
+        // However, we should be able to detect that the key exists
+        val keyExists = KeyCompatibilityManager.hasPrivateKey(testPrefix, storage)
+        assertTrue("Should detect that hardware-backed key exists", keyExists)
+        
+        // And diagnostic should provide useful information
+        val diagnostic = KeyCompatibilityManager.diagnoseKeyStorage(testPrefix, storage)
+        assertTrue("Diagnostic should mention old Android Keystore", diagnostic.contains("Old Android Keystore"))
+        assertTrue("Diagnostic should indicate key found", diagnostic.contains("Found"))
+    }
+
+    /**
+     * Creates a real EC private key in Android Keystore for testing.
+     * 
+     * Note: This creates a software-backed key that allows extraction of private key material.
+     * In production, keys would be hardware-backed and non-extractable for security.
+     */
+    private fun createTestKeyInAndroidKeystore() {
+        try {
+            val keyPairGenerator = KeyPairGenerator.getInstance("EC", "AndroidKeyStore")
+            val spec = android.security.keystore.KeyGenParameterSpec.Builder(
+                oldKeystoreAlias,
+                android.security.keystore.KeyProperties.PURPOSE_SIGN or 
+                android.security.keystore.KeyProperties.PURPOSE_VERIFY
+            )
+                .setAlgorithmParameterSpec(ECGenParameterSpec("secp256r1"))
+                .setDigests(android.security.keystore.KeyProperties.DIGEST_SHA256)
+                // Make key extractable for testing - this allows migration
+                .setUserAuthenticationRequired(false)
+                .build()
+
+            keyPairGenerator.initialize(spec)
+            val keyPair = keyPairGenerator.generateKeyPair()
+            
+            // Verify the key was created
+            val keyStore = KeyStore.getInstance("AndroidKeyStore")
+            keyStore.load(null)
+            assertTrue("Key should exist in Android Keystore", keyStore.containsAlias(oldKeystoreAlias))
+            
+        } catch (e: Exception) {
+            fail("Failed to create test key in Android Keystore: ${e.message}")
+        }
+    }
+}

--- a/app/src/main/java/com/flowfoundation/wallet/manager/account/AccountManager.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/manager/account/AccountManager.kt
@@ -84,6 +84,13 @@ object AccountManager {
         
         ioScope {
             try {
+                // Perform keystore migration before loading accounts
+                try {
+                    logd(TAG, "Performing keystore migration check...")
+                    KeyStoreMigrationManager.performMigrationIfNeeded()
+                } catch (e: Exception) {
+                    logd(TAG, "Error during keystore migration: ${e.message}")
+                }
                 // Load user prefixes first
                 val userPrefixList = UserPrefixCacheManager.read()
                 if (!userPrefixList.isNullOrEmpty()) {

--- a/app/src/main/java/com/flowfoundation/wallet/manager/account/AccountMigrate.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/manager/account/AccountMigrate.kt
@@ -24,6 +24,13 @@ import java.util.UUID
 // from single account to multi account
 fun accountMigrateV1(callback: (() -> Unit)? = null) {
     ioScope {
+        // First, perform keystore migration if needed
+        try {
+            KeyStoreMigrationManager.performMigrationIfNeeded()
+        } catch (e: Exception) {
+            logd("AccountMigrate", "Error during keystore migration: ${e.message}")
+        }
+        
         if (!isAccountV1DataExist()) {
             callback?.invoke()
             return@ioScope

--- a/app/src/main/java/com/flowfoundation/wallet/manager/account/KeyStoreMigrationExceptions.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/manager/account/KeyStoreMigrationExceptions.kt
@@ -3,8 +3,10 @@ package com.flowfoundation.wallet.manager.account
 /**
  * Base exception for KeyStore migration failures.
  * Provides detailed context for debugging migration issues.
+ * 
+ * Note: Using abstract class instead of sealed class to avoid ASM9 compatibility issues.
  */
-sealed class KeyStoreMigrationException(
+abstract class KeyStoreMigrationException(
     message: String,
     cause: Throwable? = null,
     val prefix: String? = null,
@@ -76,8 +78,27 @@ class InvalidPrivateKeySizeException(
     alias = alias
 ) {
     
+    /**
+     * ⚠️ SECURITY WARNING: This method exposes raw private key material!
+     * 
+     * This should ONLY be used for debugging in development builds.
+     * NEVER call this method in production code or logs, as it could
+     * expose users' private keys and compromise their funds.
+     * 
+     * @return Hex-encoded private key bytes - HIGHLY SENSITIVE MATERIAL!
+     */
     fun getKeyBytesHex(): String? {
         return keyBytes?.joinToString("") { "%02x".format(it) }
+    }
+    
+    /**
+     * Safe method to get debugging information without exposing key material.
+     * Use this method in production logging instead of getKeyBytesHex().
+     * 
+     * @return Non-sensitive debugging information
+     */
+    fun getSafeDebugInfo(): String {
+        return "actualSize=${keyBytes?.size}, expectedSize=$expectedSize, alias=$alias"
     }
 }
 

--- a/app/src/main/java/com/flowfoundation/wallet/manager/account/KeyStoreMigrationExceptions.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/manager/account/KeyStoreMigrationExceptions.kt
@@ -1,0 +1,124 @@
+package com.flowfoundation.wallet.manager.account
+
+/**
+ * Base exception for KeyStore migration failures.
+ * Provides detailed context for debugging migration issues.
+ */
+sealed class KeyStoreMigrationException(
+    message: String,
+    cause: Throwable? = null,
+    val prefix: String? = null,
+    val alias: String? = null
+) : Exception(message, cause) {
+    
+    override fun toString(): String {
+        return buildString {
+            append(this@KeyStoreMigrationException::class.simpleName)
+            append(": ")
+            append(message)
+            prefix?.let { append(" [prefix: $it]") }
+            alias?.let { append(" [alias: $it]") }
+            cause?.let { append(" [cause: ${it.message}]") }
+        }
+    }
+}
+
+/**
+ * Thrown when a key cannot be found in the Android Keystore
+ */
+class KeystoreKeyNotFoundException(
+    alias: String,
+    prefix: String? = null
+) : KeyStoreMigrationException(
+    message = "Private key not found in Android Keystore",
+    prefix = prefix,
+    alias = alias
+)
+
+/**
+ * Thrown when the keystore entry exists but is not a private key entry
+ */
+class InvalidKeystoreEntryException(
+    alias: String,
+    entryType: String,
+    prefix: String? = null
+) : KeyStoreMigrationException(
+    message = "Keystore entry is not a PrivateKeyEntry (found: $entryType)",
+    prefix = prefix,
+    alias = alias
+)
+
+/**
+ * Thrown when the private key is not an EC key
+ */
+class UnsupportedKeyTypeException(
+    alias: String,
+    keyType: String,
+    prefix: String? = null
+) : KeyStoreMigrationException(
+    message = "Private key is not an EC key (found: $keyType)",
+    prefix = prefix,
+    alias = alias
+)
+
+/**
+ * Thrown when the private key size is unexpected and cannot be normalized
+ */
+class InvalidPrivateKeySizeException(
+    alias: String,
+    actualSize: Int,
+    expectedSize: Int = 32,
+    prefix: String? = null,
+    val keyBytes: ByteArray? = null
+) : KeyStoreMigrationException(
+    message = "Private key has unexpected size: $actualSize bytes (expected: $expectedSize bytes). This could indicate key corruption or unsupported key format.",
+    prefix = prefix,
+    alias = alias
+) {
+    
+    fun getKeyBytesHex(): String? {
+        return keyBytes?.joinToString("") { "%02x".format(it) }
+    }
+}
+
+/**
+ * Thrown when private key extraction fails due to Android Keystore access issues
+ */
+class KeystoreAccessException(
+    alias: String,
+    cause: Throwable,
+    prefix: String? = null
+) : KeyStoreMigrationException(
+    message = "Failed to access Android Keystore",
+    cause = cause,
+    prefix = prefix,
+    alias = alias
+)
+
+/**
+ * Thrown when the migrated key fails verification
+ */
+class KeyMigrationVerificationException(
+    keyId: String,
+    prefix: String? = null,
+    cause: Throwable? = null
+) : KeyStoreMigrationException(
+    message = "Migrated key failed verification - could not generate public key",
+    cause = cause,
+    prefix = prefix,
+    alias = keyId
+)
+
+/**
+ * Thrown when storing the migrated key fails
+ */
+class KeyMigrationStorageException(
+    keyId: String,
+    prefix: String? = null,
+    cause: Throwable? = null
+) : KeyStoreMigrationException(
+    message = "Failed to store migrated key in new storage system",
+    cause = cause,
+    prefix = prefix,
+    alias = keyId
+) 

--- a/app/src/main/java/com/flowfoundation/wallet/manager/account/KeyStoreMigrationExceptions.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/manager/account/KeyStoreMigrationExceptions.kt
@@ -69,7 +69,7 @@ class UnsupportedKeyTypeException(
 class InvalidPrivateKeySizeException(
     alias: String,
     actualSize: Int,
-    expectedSize: Int = 32,
+    val expectedSize: Int = 32,
     prefix: String? = null,
     val keyBytes: ByteArray? = null
 ) : KeyStoreMigrationException(

--- a/app/src/main/java/com/flowfoundation/wallet/manager/account/KeyStoreMigrationManager.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/manager/account/KeyStoreMigrationManager.kt
@@ -1,0 +1,276 @@
+package com.flowfoundation.wallet.manager.account
+
+import com.flow.wallet.keys.PrivateKey
+import com.flow.wallet.keys.KeyFormat
+import com.flow.wallet.storage.StorageProtocol
+import com.flowfoundation.wallet.cache.AccountCacheManager
+import com.flowfoundation.wallet.utils.Env.getStorage
+import com.flowfoundation.wallet.utils.logd
+import com.flowfoundation.wallet.utils.logw
+import org.onflow.flow.models.SigningAlgorithm
+import java.security.KeyStore
+import java.security.KeyStore.PrivateKeyEntry
+import java.security.interfaces.ECPrivateKey
+
+/**
+ * Manages migration of private keys from the old Android Keystore system
+ * to the new Flow-Wallet-Kit storage system.
+ * 
+ * This is critical for users upgrading from versions that used direct Android Keystore access
+ * to versions that use the Flow-Wallet-Kit storage abstraction.
+ */
+object KeyStoreMigrationManager {
+    private const val TAG = "KeyStoreMigration"
+    private const val OLD_KEYSTORE_ALIAS_PREFIX = "user_keystore_"
+    private const val MIGRATION_COMPLETED_KEY = "keystore_migration_completed"
+    
+    /**
+     * Performs migration of private keys from old Android Keystore to new storage system.
+     * This should be called during app startup before any wallet operations.
+     */
+    suspend fun performMigrationIfNeeded() {
+        logd(TAG, "=== Starting KeyStore Migration Check ===")
+        
+        try {
+            // Check if migration has already been completed
+            if (isMigrationCompleted()) {
+                logd(TAG, "Migration already completed, skipping.")
+                return
+            }
+            
+            // Get all accounts that might need migration
+            val accounts = AccountCacheManager.read() ?: emptyList()
+            logd(TAG, "Found ${accounts.size} accounts to check for migration")
+            
+            val storage = getStorage()
+            var migrationPerformed = false
+            
+            // Check each account
+            for (account in accounts) {
+                val prefix = account.prefix
+                if (!prefix.isNullOrBlank()) {
+                    logd(TAG, "Checking account with prefix: $prefix")
+                    
+                    // Check if the account already has a key in the new storage system
+                    val newKeyId = "prefix_key_$prefix"
+                    if (hasKeyInNewStorage(newKeyId, prefix, storage)) {
+                        logd(TAG, "Account $prefix already has key in new storage, skipping")
+                        continue
+                    }
+                    
+                    // Check if the account has a key in the old Android Keystore
+                    val oldAlias = OLD_KEYSTORE_ALIAS_PREFIX + prefix
+                    val privateKeyData = extractPrivateKeyFromAndroidKeystore(oldAlias)
+                    
+                    if (privateKeyData != null) {
+                        logd(TAG, "Found private key in old keystore for prefix: $prefix")
+                        
+                        // Migrate the key to the new storage system
+                        if (migratePrivateKey(privateKeyData, newKeyId, prefix, storage)) {
+                            logd(TAG, "Successfully migrated key for prefix: $prefix")
+                            migrationPerformed = true
+                        } else {
+                            logd(TAG, "Failed to migrate key for prefix: $prefix")
+                        }
+                    } else {
+                        logd(TAG, "No key found in old keystore for prefix: $prefix")
+                    }
+                }
+            }
+            
+            // Mark migration as completed if any migration was performed or no migration was needed
+            if (migrationPerformed || accounts.isEmpty()) {
+                markMigrationCompleted()
+                logd(TAG, "Migration process completed successfully")
+            }
+            
+        } catch (e: Exception) {
+            logd(TAG, "Error during migration: ${e.message}")
+            // Don't mark as completed if there was an error
+        }
+        
+        logd(TAG, "=== KeyStore Migration Check Completed ===")
+    }
+    
+    /**
+     * Checks if a key exists in the new storage system
+     */
+    private fun hasKeyInNewStorage(keyId: String, password: String, storage: StorageProtocol): Boolean {
+        return try {
+            PrivateKey.get(keyId, password, storage)
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
+    
+    /**
+     * Extracts private key data from the old Android Keystore system
+     */
+    private fun extractPrivateKeyFromAndroidKeystore(alias: String): ByteArray? {
+        return try {
+            logd(TAG, "Attempting to extract key from Android Keystore with alias: $alias")
+            
+            val keyStore = KeyStore.getInstance("AndroidKeyStore")
+            keyStore.load(null)
+            
+            if (!keyStore.containsAlias(alias)) {
+                logd(TAG, "Alias $alias not found in Android Keystore")
+                return null
+            }
+            
+            val keyEntry = keyStore.getEntry(alias, null) as? PrivateKeyEntry
+            if (keyEntry == null) {
+                logw(TAG, "Key entry not found for alias: $alias")
+                return null
+            }
+            
+            val privateKey = keyEntry.privateKey as? ECPrivateKey
+            if (privateKey == null) {
+                logw(TAG, "Private key is not an EC key for alias: $alias")
+                return null
+            }
+            
+            // Extract the private key value as raw bytes
+            val privateKeyValue = privateKey.s
+            val privateKeyBytes = privateKeyValue.toByteArray()
+            
+            // Ensure the key is 32 bytes (pad with zeros if necessary)
+            val normalizedBytes = when {
+                privateKeyBytes.size == 32 -> privateKeyBytes
+                privateKeyBytes.size == 33 && privateKeyBytes[0] == 0.toByte() -> 
+                    privateKeyBytes.copyOfRange(1, 33) // Remove leading zero byte
+                privateKeyBytes.size < 32 -> {
+                    val padded = ByteArray(32)
+                    System.arraycopy(privateKeyBytes, 0, padded, 32 - privateKeyBytes.size, privateKeyBytes.size)
+                    padded
+                }
+                else -> {
+                    logw(TAG, "Unexpected private key size: ${privateKeyBytes.size}")
+                    return null
+                }
+            }
+            
+            logd(TAG, "Successfully extracted private key from Android Keystore")
+            normalizedBytes
+            
+        } catch (e: Exception) {
+            logd(TAG, "Error extracting private key from Android Keystore: ${e.message}")
+            null
+        }
+    }
+    
+    /**
+     * Migrates a private key to the new storage system
+     */
+    private suspend fun migratePrivateKey(
+        privateKeyData: ByteArray, 
+        keyId: String, 
+        password: String, 
+        storage: StorageProtocol
+    ): Boolean {
+        return try {
+            logd(TAG, "Migrating private key to new storage with ID: $keyId")
+            
+            // Create a new PrivateKey instance using Flow-Wallet-Kit
+            val privateKey = PrivateKey.create(storage)
+            
+            // Import the raw private key data
+            privateKey.importPrivateKey(privateKeyData, KeyFormat.RAW)
+            
+            // Store the key with the new ID pattern
+            privateKey.store(keyId, password)
+            
+            // Verify the key was stored correctly by attempting to retrieve it
+            val retrievedKey = PrivateKey.get(keyId, password, storage)
+            
+            // Verify the key works by generating a public key
+            val publicKey = retrievedKey.publicKey(SigningAlgorithm.ECDSA_P256)
+            if (publicKey == null) {
+                logd(TAG, "Failed to generate public key from migrated private key")
+                return false
+            }
+            
+            logd(TAG, "Successfully migrated and verified private key")
+            true
+            
+        } catch (e: Exception) {
+            logd(TAG, "Error migrating private key: ${e.message}")
+            false
+        }
+    }
+    
+    /**
+     * Checks if migration has already been completed
+     */
+    private fun isMigrationCompleted(): Boolean {
+        return try {
+            val storage = getStorage()
+            storage.get(MIGRATION_COMPLETED_KEY) != null
+        } catch (e: Exception) {
+            false
+        }
+    }
+    
+    /**
+     * Public method to check migration status (for diagnostics)
+     */
+    fun getMigrationStatus(): Boolean {
+        return try {
+            val storage = getStorage()
+            storage.get(MIGRATION_COMPLETED_KEY) != null
+        } catch (e: Exception) {
+            false
+        }
+    }
+    
+    /**
+     * Marks migration as completed
+     */
+    private fun markMigrationCompleted() {
+        try {
+            val storage = getStorage()
+            storage.set(MIGRATION_COMPLETED_KEY, "completed".toByteArray())
+            logd(TAG, "Marked migration as completed")
+        } catch (e: Exception) {
+            logd(TAG, "Error marking migration as completed: ${e.message}")
+        }
+    }
+    
+    /**
+     * Forces re-migration (for testing purposes only)
+     */
+    fun resetMigrationStatus() {
+        try {
+            val storage = getStorage()
+            storage.remove(MIGRATION_COMPLETED_KEY)
+            logd(TAG, "Reset migration status")
+        } catch (e: Exception) {
+            logd(TAG, "Error resetting migration status: ${e.message}")
+        }
+    }
+    
+    /**
+     * Diagnostic function to list all keys in Android Keystore
+     */
+    fun diagnoseAndroidKeystore(): List<String> {
+        return try {
+            val keyStore = KeyStore.getInstance("AndroidKeyStore")
+            keyStore.load(null)
+            
+            val aliases = mutableListOf<String>()
+            val enumeration = keyStore.aliases()
+            while (enumeration.hasMoreElements()) {
+                val alias = enumeration.nextElement()
+                aliases.add(alias)
+                logd(TAG, "Found alias in Android Keystore: $alias")
+            }
+            
+            logd(TAG, "Total aliases in Android Keystore: ${aliases.size}")
+            aliases
+        } catch (e: Exception) {
+            logd(TAG, "Error diagnosing Android Keystore: ${e.message}")
+            emptyList()
+        }
+    }
+} 

--- a/app/src/main/java/com/flowfoundation/wallet/manager/account/KeyStoreMigrationManager.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/manager/account/KeyStoreMigrationManager.kt
@@ -15,139 +15,152 @@ import java.security.interfaces.ECPrivateKey
 /**
  * Manages migration of private keys from the old Android Keystore system
  * to the new Flow-Wallet-Kit storage system.
- * 
+ *
  * This is critical for users upgrading from versions that used direct Android Keystore access
  * to versions that use the Flow-Wallet-Kit storage abstraction.
+ *
  */
 object KeyStoreMigrationManager {
     private const val TAG = "KeyStoreMigration"
     private const val OLD_KEYSTORE_ALIAS_PREFIX = "user_keystore_"
     private const val MIGRATION_COMPLETED_KEY = "keystore_migration_completed"
+    private const val MIGRATION_RETRY_COUNT_KEY = "keystore_migration_retry_count"
+    private const val MIGRATION_LAST_ATTEMPT_KEY = "keystore_migration_last_attempt"
+    private const val MAX_RETRY_ATTEMPTS = 3
+    private const val RETRY_DELAY_HOURS = 24
+    private const val MAX_CONCURRENT_MIGRATIONS = 5
+
+    /**
+     * Result of a migration operation
+     */
+    abstract class MigrationResult {
+        object AlreadyCompleted : MigrationResult()
+        object SkippedDueToRetryLimit : MigrationResult()
+        data class Success(val migratedCount: Int, val totalAccounts: Int, val warnings: List<String> = emptyList()) : MigrationResult()
+        data class PartialSuccess(val migratedCount: Int, val totalAccounts: Int, val failures: List<MigrationFailure>) : MigrationResult()
+        data class Failed(val reason: String, val failures: List<MigrationFailure> = emptyList()) : MigrationResult()
+    }
+
+    /**
+     * Details about a failed migration
+     */
+    data class MigrationFailure(
+        val prefix: String,
+        val error: KeyStoreMigrationException,
+        val canRetry: Boolean
+    )
+
+    /**
+     * Tracks migration progress
+     */
+    private data class MigrationState(
+        var totalAccountsProcessed: Int = 0,
+        var successfulMigrations: Int = 0,
+        var accountsNeedingMigration: Int = 0,
+        var accountsSkipped: Int = 0
+    )
     
+    /**
+     * Result of migrating a single account
+     */
+    private abstract class AccountMigrationResult {
+        data class Success(val wasAlreadyMigrated: Boolean) : AccountMigrationResult()
+        object NotNeeded : AccountMigrationResult()
+        data class Failed(val error: KeyStoreMigrationException, val canRetry: Boolean) : AccountMigrationResult()
+    }
+
     /**
      * Performs migration of private keys from old Android Keystore to new storage system.
      * This should be called during app startup before any wallet operations.
      */
-    suspend fun performMigrationIfNeeded() {
+    suspend fun performMigrationIfNeeded(): MigrationResult {
         logd(TAG, "=== Starting KeyStore Migration Check ===")
-        
+
         try {
             // Check if migration has already been completed
             if (isMigrationCompleted()) {
                 logd(TAG, "Migration already completed, skipping.")
-                return
+                return MigrationResult.AlreadyCompleted
             }
-            
+
+            // Check retry conditions
+            if (!shouldAttemptMigration()) {
+                logd(TAG, "Migration retry conditions not met, skipping.")
+                return MigrationResult.SkippedDueToRetryLimit
+            }
+
+            // Record migration attempt
+            recordMigrationAttempt()
+
             // Get all accounts that might need migration
             val accounts = AccountCacheManager.read() ?: emptyList()
             logd(TAG, "Found ${accounts.size} accounts to check for migration")
-            
+
             val storage = getStorage()
-            var totalAccountsProcessed = 0
-            var successfulMigrations = 0
-            var accountsNeedingMigration = 0
+            val migrationState = MigrationState()
+            val failedAccounts = mutableListOf<MigrationFailure>()
+
+            // Process accounts with improved error handling and retry logic
+            val accountsToProcess = accounts.filter { !it.prefix.isNullOrBlank() }
+            logd(TAG, "Processing ${accountsToProcess.size} accounts with valid prefixes")
             
-            // Check each account
-            for (account in accounts) {
-                val prefix = account.prefix
-                if (!prefix.isNullOrBlank()) {
-                    totalAccountsProcessed++
-                    logd(TAG, "Checking account with prefix: $prefix")
-                    
-                    // Check if the account already has a key in the new storage system
-                    val newKeyId = "prefix_key_$prefix"
-                    if (hasKeyInNewStorage(newKeyId, prefix, storage)) {
-                        logd(TAG, "Account $prefix already has key in new storage, skipping")
-                        successfulMigrations++ // Already migrated counts as success
-                        continue
+            for (account in accountsToProcess) {
+                val prefix = account.prefix!!
+                migrationState.totalAccountsProcessed++
+                
+                try {
+                    val migrationResult = migrateAccountWithRetry(prefix, storage, migrationState)
+                    when (migrationResult) {
+                        is AccountMigrationResult.Success -> {
+                            migrationState.successfulMigrations++
+                            if (migrationResult.wasAlreadyMigrated) {
+                                logd(TAG, "Account $prefix already migrated")
+                            } else {
+                                logd(TAG, "Successfully migrated account $prefix")
+                                migrationState.accountsNeedingMigration++
+                            }
+                        }
+                        is AccountMigrationResult.NotNeeded -> {
+                            migrationState.successfulMigrations++
+                            migrationState.accountsSkipped++
+                            logd(TAG, "Account $prefix does not need migration")
+                        }
+                        is AccountMigrationResult.Failed -> {
+                            val failure = MigrationFailure(
+                                prefix = prefix,
+                                error = migrationResult.error,
+                                canRetry = migrationResult.canRetry
+                            )
+                            failedAccounts.add(failure)
+                            migrationState.accountsNeedingMigration++
+                            loge(TAG, "Failed to migrate account $prefix: ${migrationResult.error.message}")
+                        }
                     }
-                    
-                    // Attempt to migrate the key from old Android Keystore
-                    val oldAlias = OLD_KEYSTORE_ALIAS_PREFIX + prefix
-                    try {
-                        logd(TAG, "Attempting to extract key from old keystore for prefix: $prefix")
-                        val privateKeyData = extractPrivateKeyFromAndroidKeystore(oldAlias)
-                        
-                        logd(TAG, "Found private key in old keystore for prefix: $prefix")
-                        accountsNeedingMigration++
-                        
-                        // Migrate the key to the new storage system
-                        migratePrivateKey(privateKeyData, newKeyId, prefix, storage)
-                        logd(TAG, "Successfully migrated key for prefix: $prefix")
-                        successfulMigrations++
-                        
-                    } catch (e: KeystoreKeyNotFoundException) {
-                        logd(TAG, "No key found in old keystore for prefix: $prefix (not an error - may be new account)")
-                        successfulMigrations++ // No migration needed counts as success
-                    } catch (e: InvalidPrivateKeySizeException) {
-                        loge(TAG, "CRITICAL: Invalid private key size for prefix $prefix: ${e.message}")
-                        loge(TAG, "This account may require manual recovery or the key may be corrupted")
-                        accountsNeedingMigration++
-                        // Note: successfulMigrations is NOT incremented - this is a failure
-                    } catch (e: KeyStoreMigrationException) {
-                        loge(TAG, "Migration failed for prefix $prefix: $e")
-                        loge(TAG, "Account may need manual intervention or alternative recovery method")
-                        accountsNeedingMigration++
-                        // Note: successfulMigrations is NOT incremented - this is a failure
-                    } catch (e: Exception) {
-                        loge(TAG, "Unexpected error migrating key for prefix $prefix: ${e.message}")
-                        accountsNeedingMigration++
-                        // Note: successfulMigrations is NOT incremented - this is a failure
-                    }
+                } catch (e: Exception) {
+                    // Unexpected error - wrap in generic migration exception
+                    val failure = MigrationFailure(
+                        prefix = prefix,
+                        error = KeystoreAccessException(prefix, e),
+                        canRetry = true
+                    )
+                    failedAccounts.add(failure)
+                    migrationState.accountsNeedingMigration++
+                    loge(TAG, "Unexpected error processing account $prefix: ${e.message}")
                 }
             }
+
+            // Determine final result and mark completion if appropriate
+            val result = determineAndMarkMigrationResult(accounts, migrationState, failedAccounts)
+            logd(TAG, "Migration completed with result: $result")
             
-            // Determine if migration should be marked as completed
-            logd(TAG, "Migration Summary:")
-            logd(TAG, "- Total accounts processed: $totalAccountsProcessed")
-            logd(TAG, "- Successful migrations: $successfulMigrations") 
-            logd(TAG, "- Accounts that needed migration: $accountsNeedingMigration")
-            
-            val shouldMarkCompleted = when {
-                // Case 1: No accounts exist - nothing to migrate
-                accounts.isEmpty() -> {
-                    logd(TAG, "No accounts found - marking migration as completed")
-                    true
-                }
-                
-                // Case 2: No accounts have prefix (all keystore-based) - no migration needed
-                totalAccountsProcessed == 0 -> {
-                    logd(TAG, "No prefix-based accounts found - marking migration as completed")
-                    true
-                }
-                
-                // Case 3: All accounts were successfully processed
-                successfulMigrations == totalAccountsProcessed -> {
-                    logd(TAG, "All accounts successfully processed - marking migration as completed")
-                    true
-                }
-                
-                // Case 4: Some accounts failed - DO NOT mark as completed
-                successfulMigrations < totalAccountsProcessed -> {
-                    loge(TAG, "Some accounts failed migration - NOT marking as completed")
-                    loge(TAG, "Failed accounts: ${totalAccountsProcessed - successfulMigrations}")
-                    loge(TAG, "Migration will be retried on next app launch")
-                    false
-                }
-                
-                else -> false
-            }
-            
-            if (shouldMarkCompleted) {
-                markMigrationCompleted()
-                logd(TAG, "Migration process completed successfully")
-            } else {
-                logd(TAG, "Migration process completed with failures - will retry on next launch")
-            }
-            
+            return result
+
         } catch (e: Exception) {
-            logd(TAG, "Error during migration: ${e.message}")
-            // Don't mark as completed if there was an error
+            loge(TAG, "Critical error during migration: ${e.message}")
+            return MigrationResult.Failed("Critical migration error: ${e.message}")
         }
-        
-        logd(TAG, "=== KeyStore Migration Check Completed ===")
     }
-    
+
     /**
      * Checks if a key exists in the new storage system
      */
@@ -159,7 +172,7 @@ object KeyStoreMigrationManager {
             false
         }
     }
-    
+
     /**
      * Extracts private key data from the old Android Keystore system
      * @throws KeyStoreMigrationException with specific details about the failure
@@ -167,32 +180,32 @@ object KeyStoreMigrationManager {
     private fun extractPrivateKeyFromAndroidKeystore(alias: String): ByteArray {
         try {
             logd(TAG, "Attempting to extract key from Android Keystore with alias: $alias")
-            
+
             val keyStore = KeyStore.getInstance("AndroidKeyStore")
             keyStore.load(null)
-            
+
             if (!keyStore.containsAlias(alias)) {
                 throw KeystoreKeyNotFoundException(alias)
             }
-            
+
             val keyEntry = keyStore.getEntry(alias, null)
             if (keyEntry !is PrivateKeyEntry) {
                 val entryType = keyEntry?.javaClass?.simpleName ?: "null"
                 throw InvalidKeystoreEntryException(alias, entryType)
             }
-            
+
             val privateKey = keyEntry.privateKey
             if (privateKey !is ECPrivateKey) {
                 val keyType = privateKey?.javaClass?.simpleName ?: "null"
                 throw UnsupportedKeyTypeException(alias, keyType)
             }
-            
+
             // Extract the private key value as raw bytes
             val privateKeyValue = privateKey.s
             val privateKeyBytes = privateKeyValue.toByteArray()
-            
+
             logd(TAG, "Extracted private key with size: ${privateKeyBytes.size} bytes")
-            
+
             // Ensure the key is 32 bytes (normalize different formats)
             val normalizedBytes = when {
                 privateKeyBytes.size == 32 -> {
@@ -212,7 +225,7 @@ object KeyStoreMigrationManager {
                 else -> {
                     // This is the critical improvement - throw specific exception instead of returning null
                     loge(TAG, "Private key has unexpected size: ${privateKeyBytes.size} bytes (expected: 32)")
-                    
+
                     throw InvalidPrivateKeySizeException(
                         alias = alias,
                         actualSize = privateKeyBytes.size,
@@ -220,10 +233,10 @@ object KeyStoreMigrationManager {
                     )
                 }
             }
-            
+
             logd(TAG, "Successfully extracted and normalized private key from Android Keystore")
             return normalizedBytes
-            
+
         } catch (e: KeyStoreMigrationException) {
             // Re-throw our specific exceptions
             loge(TAG, "Key extraction failed: $e")
@@ -234,43 +247,43 @@ object KeyStoreMigrationManager {
             throw KeystoreAccessException(alias, e)
         }
     }
-    
+
     /**
      * Migrates a private key to the new storage system
      * @throws KeyStoreMigrationException with specific details about the failure
      */
     private suspend fun migratePrivateKey(
-        privateKeyData: ByteArray, 
-        keyId: String, 
-        password: String, 
+        privateKeyData: ByteArray,
+        keyId: String,
+        password: String,
         storage: StorageProtocol
     ) {
         try {
             logd(TAG, "Migrating private key to new storage with ID: $keyId")
             logd(TAG, "Private key data size: ${privateKeyData.size} bytes")
-            
+
             // Create a new PrivateKey instance using Flow-Wallet-Kit
             val privateKey = PrivateKey.create(storage)
-            
+
             // Import the raw private key data
             privateKey.importPrivateKey(privateKeyData, KeyFormat.RAW)
             logd(TAG, "Successfully imported private key data")
-            
+
             // Store the key with the new ID pattern
             privateKey.store(keyId, password)
             logd(TAG, "Successfully stored private key with new ID")
-            
+
             // Verify the key was stored correctly by attempting to retrieve it
             val retrievedKey = PrivateKey.get(keyId, password, storage)
             logd(TAG, "Successfully retrieved stored private key for verification")
-            
+
             // Verify the key works by generating a public key
             val publicKey = retrievedKey.publicKey(SigningAlgorithm.ECDSA_P256)
                 ?: throw KeyMigrationVerificationException(keyId, password)
 
             logd(TAG, "Successfully migrated and verified private key")
             logd(TAG, "Generated public key size: ${publicKey.size} bytes")
-            
+
         } catch (e: KeyStoreMigrationException) {
             // Re-throw our specific exceptions
             loge(TAG, "Key migration failed: $e")
@@ -281,7 +294,7 @@ object KeyStoreMigrationManager {
             throw KeyMigrationStorageException(keyId, password, e)
         }
     }
-    
+
     /**
      * Checks if migration has already been completed
      */
@@ -293,7 +306,7 @@ object KeyStoreMigrationManager {
             false
         }
     }
-    
+
     /**
      * Marks migration as completed
      */
@@ -306,7 +319,7 @@ object KeyStoreMigrationManager {
             logd(TAG, "Error marking migration as completed: ${e.message}")
         }
     }
-    
+
     /**
      * Diagnostic function to list all keys in Android Keystore
      */
@@ -314,7 +327,7 @@ object KeyStoreMigrationManager {
         return try {
             val keyStore = KeyStore.getInstance("AndroidKeyStore")
             keyStore.load(null)
-            
+
             val aliases = mutableListOf<String>()
             val enumeration = keyStore.aliases()
             while (enumeration.hasMoreElements()) {
@@ -322,7 +335,7 @@ object KeyStoreMigrationManager {
                 aliases.add(alias)
                 logd(TAG, "Found alias in Android Keystore: $alias")
             }
-            
+
             logd(TAG, "Total aliases in Android Keystore: ${aliases.size}")
             aliases
         } catch (e: Exception) {
@@ -330,4 +343,191 @@ object KeyStoreMigrationManager {
             emptyList()
         }
     }
-} 
+    
+    /**
+     * Checks if we should attempt migration based on retry logic
+     */
+    private fun shouldAttemptMigration(): Boolean {
+        return try {
+            val storage = getStorage()
+            val retryCountBytes = storage.get(MIGRATION_RETRY_COUNT_KEY)
+            val retryCount = retryCountBytes?.let { String(it).toIntOrNull() } ?: 0
+            
+            if (retryCount >= MAX_RETRY_ATTEMPTS) {
+                val lastAttemptBytes = storage.get(MIGRATION_LAST_ATTEMPT_KEY)
+                val lastAttempt = lastAttemptBytes?.let { String(it).toLongOrNull() } ?: 0
+                val hoursSinceLastAttempt = (System.currentTimeMillis() - lastAttempt) / (1000 * 60 * 60)
+                
+                if (hoursSinceLastAttempt < RETRY_DELAY_HOURS) {
+                    logd(TAG, "Migration retry limit reached ($retryCount/$MAX_RETRY_ATTEMPTS), waiting $RETRY_DELAY_HOURS hours")
+                    return false
+                } else {
+                    logd(TAG, "Retry delay period passed, resetting retry count")
+                    storage.set(MIGRATION_RETRY_COUNT_KEY, "0".toByteArray())
+                }
+            }
+            
+            true
+        } catch (e: Exception) {
+            loge(TAG, "Error checking retry conditions: ${e.message}")
+            true // Default to allowing attempt
+        }
+    }
+    
+    /**
+     * Records a migration attempt for retry tracking
+     */
+    private fun recordMigrationAttempt() {
+        try {
+            val storage = getStorage()
+            val retryCountBytes = storage.get(MIGRATION_RETRY_COUNT_KEY)
+            val retryCount = retryCountBytes?.let { String(it).toIntOrNull() } ?: 0
+            
+            storage.set(MIGRATION_RETRY_COUNT_KEY, (retryCount + 1).toString().toByteArray())
+            storage.set(MIGRATION_LAST_ATTEMPT_KEY, System.currentTimeMillis().toString().toByteArray())
+            
+            logd(TAG, "Recorded migration attempt #${retryCount + 1}")
+        } catch (e: Exception) {
+            loge(TAG, "Error recording migration attempt: ${e.message}")
+        }
+    }
+    
+    /**
+     * Migrates a single account with retry logic and improved error handling
+     */
+    private suspend fun migrateAccountWithRetry(
+        prefix: String, 
+        storage: StorageProtocol, 
+        migrationState: MigrationState
+    ): AccountMigrationResult {
+        logd(TAG, "Processing account with prefix: $prefix")
+        
+        // Check if the account already has a key in the new storage system
+        val newKeyId = "prefix_key_$prefix"
+        if (hasKeyInNewStorage(newKeyId, prefix, storage)) {
+            logd(TAG, "Account $prefix already has key in new storage")
+            return AccountMigrationResult.Success(wasAlreadyMigrated = true)
+        }
+        
+        // Attempt to migrate the key from old Android Keystore
+        val oldAlias = OLD_KEYSTORE_ALIAS_PREFIX + prefix
+        
+        return try {
+            logd(TAG, "Attempting to extract key from old keystore for prefix: $prefix")
+            val privateKeyData = extractPrivateKeyFromAndroidKeystore(oldAlias)
+            
+            logd(TAG, "Found private key in old keystore for prefix: $prefix")
+            
+            // Migrate the key to the new storage system
+            migratePrivateKey(privateKeyData, newKeyId, prefix, storage)
+            logd(TAG, "Successfully migrated key for prefix: $prefix")
+            
+            AccountMigrationResult.Success(wasAlreadyMigrated = false)
+            
+        } catch (e: KeystoreKeyNotFoundException) {
+            logd(TAG, "No key found in old keystore for prefix: $prefix (not an error - may be new account)")
+            AccountMigrationResult.NotNeeded
+            
+        } catch (e: InvalidPrivateKeySizeException) {
+            loge(TAG, "CRITICAL: Invalid private key size for prefix $prefix: ${e.getSafeDebugInfo()}")
+            AccountMigrationResult.Failed(e, canRetry = false) // Size issues usually can't be retried
+            
+        } catch (e: KeyStoreMigrationException) {
+            loge(TAG, "Migration failed for prefix $prefix: $e")
+            val canRetry = when (e) {
+                is KeystoreAccessException -> true // Network/storage issues can be retried
+                is KeyMigrationStorageException -> true // Storage issues can be retried
+                is KeyMigrationVerificationException -> false // Verification failures are persistent
+                else -> true // Default to retryable
+            }
+            AccountMigrationResult.Failed(e, canRetry = canRetry)
+            
+        } catch (e: Exception) {
+            loge(TAG, "Unexpected error migrating key for prefix $prefix: ${e.message}")
+            AccountMigrationResult.Failed(KeystoreAccessException(oldAlias, e), canRetry = true)
+        }
+    }
+    
+    /**
+     * Determines the final migration result and marks completion if appropriate
+     */
+    private fun determineAndMarkMigrationResult(
+        accounts: List<Account>,
+        migrationState: MigrationState,
+        failedAccounts: List<MigrationFailure>
+    ): MigrationResult {
+        logd(TAG, "=== Migration Summary ===")
+        logd(TAG, "- Total accounts processed: ${migrationState.totalAccountsProcessed}")
+        logd(TAG, "- Successful migrations: ${migrationState.successfulMigrations}")
+        logd(TAG, "- Accounts needing migration: ${migrationState.accountsNeedingMigration}")
+        logd(TAG, "- Accounts skipped: ${migrationState.accountsSkipped}")
+        logd(TAG, "- Failed accounts: ${failedAccounts.size}")
+        
+        val warnings = mutableListOf<String>()
+        
+        // Determine if migration should be marked as completed
+        val shouldMarkCompleted = when {
+            // Case 1: No accounts exist - nothing to migrate
+            accounts.isEmpty() -> {
+                logd(TAG, "No accounts found - marking migration as completed")
+                true
+            }
+            
+            // Case 2: No accounts have prefix (all keystore-based) - no migration needed
+            migrationState.totalAccountsProcessed == 0 -> {
+                logd(TAG, "No prefix-based accounts found - marking migration as completed")
+                warnings.add("No accounts with prefix found")
+                true
+            }
+            
+            // Case 3: All accounts were successfully processed
+            failedAccounts.isEmpty() -> {
+                logd(TAG, "All accounts successfully processed - marking migration as completed")
+                true
+            }
+            
+            // Case 4: Some accounts failed but none can be retried
+            failedAccounts.isNotEmpty() && failedAccounts.none { it.canRetry } -> {
+                logd(TAG, "Some accounts failed but none can be retried - marking as completed")
+                warnings.add("${failedAccounts.size} accounts failed migration with non-retryable errors")
+                true
+            }
+            
+            // Case 5: Some accounts failed and can be retried - DO NOT mark as completed
+            failedAccounts.any { it.canRetry } -> {
+                loge(TAG, "Some accounts failed migration with retryable errors - NOT marking as completed")
+                loge(TAG, "Failed accounts: ${failedAccounts.size}")
+                loge(TAG, "Migration will be retried on next app launch")
+                false
+            }
+            
+            else -> false
+        }
+        
+        return if (shouldMarkCompleted) {
+            markMigrationCompleted()
+            logd(TAG, "Migration process marked as completed")
+            
+            if (failedAccounts.isEmpty()) {
+                MigrationResult.Success(
+                    migratedCount = migrationState.accountsNeedingMigration,
+                    totalAccounts = migrationState.totalAccountsProcessed,
+                    warnings = warnings
+                )
+            } else {
+                MigrationResult.PartialSuccess(
+                    migratedCount = migrationState.successfulMigrations,
+                    totalAccounts = migrationState.totalAccountsProcessed,
+                    failures = failedAccounts
+                )
+            }
+        } else {
+            logd(TAG, "Migration process completed with retryable failures")
+            MigrationResult.PartialSuccess(
+                migratedCount = migrationState.successfulMigrations,
+                totalAccounts = migrationState.totalAccountsProcessed,
+                failures = failedAccounts
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/flowfoundation/wallet/manager/key/KeyCompatibilityManager.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/manager/key/KeyCompatibilityManager.kt
@@ -1,0 +1,214 @@
+package com.flowfoundation.wallet.manager.key
+
+import com.flow.wallet.keys.PrivateKey
+import com.flow.wallet.storage.StorageProtocol
+import com.flowfoundation.wallet.utils.logd
+import com.flowfoundation.wallet.utils.loge
+import java.security.KeyStore
+import java.security.KeyStore.PrivateKeyEntry
+import java.security.interfaces.ECPrivateKey
+import com.flow.wallet.keys.KeyFormat
+import org.onflow.flow.models.SigningAlgorithm
+
+/**
+ * Handles backward compatibility between old Android Keystore pattern and new Flow-Wallet-Kit storage.
+ *
+ * Old pattern: user_keystore_{prefix} -> Android Keystore
+ * New pattern: prefix_key_{prefix} -> Flow-Wallet-Kit storage
+ */
+object KeyCompatibilityManager {
+    private const val TAG = "KeyCompatibility"
+    private const val OLD_KEYSTORE_ALIAS_PREFIX = "user_keystore_"
+    private const val NEW_STORAGE_KEY_PREFIX = "prefix_key_"
+
+    /**
+     * Attempts to get a private key with backward compatibility support.
+     * First tries the new storage pattern, then falls back to old Android Keystore pattern.
+     *
+     * @param prefix The account prefix/password
+     * @param storage The Flow-Wallet-Kit storage instance
+     * @return PrivateKey instance or null if not found in either storage
+     */
+    fun getPrivateKeyWithFallback(prefix: String, storage: StorageProtocol): PrivateKey? {
+        logd(TAG, "Attempting to get private key for prefix: $prefix")
+
+        // First try the new storage pattern
+        val newKeyId = "$NEW_STORAGE_KEY_PREFIX$prefix"
+        val newStorageKey = tryGetFromNewStorage(newKeyId, prefix, storage)
+        if (newStorageKey != null) {
+            logd(TAG, "Successfully retrieved key from new storage: $newKeyId")
+            return newStorageKey
+        }
+
+        logd(TAG, "Key not found in new storage, trying old Android Keystore pattern")
+
+        // Fallback to old Android Keystore pattern
+        val oldStorageKey = tryGetFromOldKeystore(prefix, storage)
+        if (oldStorageKey != null) {
+            logd(TAG, "Successfully retrieved key from old Android Keystore for prefix: $prefix")
+            logd(TAG, "Note: Key accessed from old storage. Migration available via KeyStoreMigrationManager if needed.")
+            return oldStorageKey
+        }
+
+        loge(TAG, "Private key not found in either new storage or old Android Keystore for prefix: $prefix")
+        return null
+    }
+
+    /**
+     * Attempts to retrieve key from new Flow-Wallet-Kit storage
+     */
+    private fun tryGetFromNewStorage(keyId: String, password: String, storage: StorageProtocol): PrivateKey? {
+        return try {
+            logd(TAG, "Trying to get key from new storage: keyId=$keyId")
+            PrivateKey.get(keyId, password, storage)
+        } catch (e: Exception) {
+            logd(TAG, "Failed to get key from new storage: ${e.message}")
+            null
+        }
+    }
+
+    /**
+     * Attempts to retrieve key from old Android Keystore and wrap it in PrivateKey
+     */
+    private fun tryGetFromOldKeystore(prefix: String, storage: StorageProtocol): PrivateKey? {
+        return try {
+            logd(TAG, "Trying to get key from old Android Keystore for prefix: $prefix")
+
+            val oldAlias = "$OLD_KEYSTORE_ALIAS_PREFIX$prefix"
+            val keyStore = KeyStore.getInstance("AndroidKeyStore")
+            keyStore.load(null)
+
+            if (!keyStore.containsAlias(oldAlias)) {
+                logd(TAG, "Old keystore alias not found: $oldAlias")
+                return null
+            }
+
+            val keyEntry = keyStore.getEntry(oldAlias, null)
+            if (keyEntry !is PrivateKeyEntry) {
+                logd(TAG, "Keystore entry is not a PrivateKeyEntry: ${keyEntry?.javaClass?.simpleName}")
+                return null
+            }
+
+            val privateKey = keyEntry.privateKey
+            if (privateKey !is ECPrivateKey) {
+                logd(TAG, "Private key is not an EC key: ${privateKey?.javaClass?.simpleName}")
+                return null
+            }
+
+            // Extract raw private key bytes
+            val privateKeyValue = privateKey.s
+            val privateKeyBytes = privateKeyValue.toByteArray()
+
+            // Normalize to 32 bytes
+            val normalizedBytes = when {
+                privateKeyBytes.size == 32 -> privateKeyBytes
+                privateKeyBytes.size == 33 && privateKeyBytes[0] == 0.toByte() -> {
+                    privateKeyBytes.copyOfRange(1, 33)
+                }
+                privateKeyBytes.size < 32 -> {
+                    val padded = ByteArray(32)
+                    System.arraycopy(privateKeyBytes, 0, padded, 32 - privateKeyBytes.size, privateKeyBytes.size)
+                    padded
+                }
+                else -> {
+                    loge(TAG, "Unexpected private key size: ${privateKeyBytes.size} bytes")
+                    return null
+                }
+            }
+
+            // Create a new PrivateKey instance from the raw bytes
+            val newPrivateKey = PrivateKey.create(storage)
+            newPrivateKey.importPrivateKey(normalizedBytes, KeyFormat.RAW)
+
+            logd(TAG, "Successfully extracted and converted old keystore key to PrivateKey")
+            return newPrivateKey
+
+        } catch (e: Exception) {
+            loge(TAG, "Failed to get key from old Android Keystore: ${e.message}")
+            null
+        }
+    }
+
+
+    /**
+     * Checks if a key exists in either storage system
+     */
+    fun hasPrivateKey(prefix: String, storage: StorageProtocol): Boolean {
+        logd(TAG, "Checking if private key exists for prefix: $prefix")
+
+        // Check new storage first
+        val newKeyId = "$NEW_STORAGE_KEY_PREFIX$prefix"
+        val hasNewKey = try {
+            PrivateKey.get(newKeyId, prefix, storage)
+            true
+        } catch (e: Exception) {
+            false
+        }
+
+        if (hasNewKey) {
+            logd(TAG, "Key found in new storage")
+            return true
+        }
+
+        // Check old Android Keystore
+        val hasOldKey = try {
+            val oldAlias = "$OLD_KEYSTORE_ALIAS_PREFIX$prefix"
+            val keyStore = KeyStore.getInstance("AndroidKeyStore")
+            keyStore.load(null)
+            keyStore.containsAlias(oldAlias)
+        } catch (e: Exception) {
+            false
+        }
+
+        if (hasOldKey) {
+            logd(TAG, "Key found in old Android Keystore")
+            return true
+        }
+
+        logd(TAG, "Key not found in either storage system")
+        return false
+    }
+
+    /**
+     * Diagnostic method to list all keys in both storage systems
+     */
+    @OptIn(ExperimentalStdlibApi::class)
+    fun diagnoseKeyStorage(prefix: String, storage: StorageProtocol): String {
+        val report = StringBuilder()
+        report.appendLine("=== Key Storage Diagnostic for prefix: $prefix ===")
+
+        // Check new storage
+        val newKeyId = "$NEW_STORAGE_KEY_PREFIX$prefix"
+        try {
+            val key = PrivateKey.get(newKeyId, prefix, storage)
+            val publicKey = key.publicKey(SigningAlgorithm.ECDSA_P256)?.toHexString()
+                ?: key.publicKey(SigningAlgorithm.ECDSA_secp256k1)?.toHexString()
+            report.appendLine("✅ New storage ($newKeyId): Found (public key: ${publicKey?.take(16)}...)")
+        } catch (e: Exception) {
+            report.appendLine("❌ New storage ($newKeyId): Not found (${e.message})")
+        }
+
+        // Check old Android Keystore
+        val oldAlias = "$OLD_KEYSTORE_ALIAS_PREFIX$prefix"
+        try {
+            val keyStore = KeyStore.getInstance("AndroidKeyStore")
+            keyStore.load(null)
+
+            if (keyStore.containsAlias(oldAlias)) {
+                val keyEntry = keyStore.getEntry(oldAlias, null)
+                if (keyEntry is PrivateKeyEntry) {
+                    report.appendLine("✅ Old Android Keystore ($oldAlias): Found (PrivateKeyEntry)")
+                } else {
+                    report.appendLine("⚠️ Old Android Keystore ($oldAlias): Found but wrong type (${keyEntry?.javaClass?.simpleName})")
+                }
+            } else {
+                report.appendLine("❌ Old Android Keystore ($oldAlias): Not found")
+            }
+        } catch (e: Exception) {
+            report.appendLine("❌ Old Android Keystore ($oldAlias): Error checking (${e.message})")
+        }
+
+        report.appendLine("=== End Diagnostic ===")
+        return report.toString()
+    }
+}

--- a/app/src/main/java/com/flowfoundation/wallet/network/UserRegisterUtils.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/network/UserRegisterUtils.kt
@@ -17,6 +17,7 @@ import com.flowfoundation.wallet.manager.account.AccountManager
 import com.flowfoundation.wallet.manager.account.DeviceInfoManager
 import com.flowfoundation.wallet.manager.app.chainNetWorkString
 import com.flowfoundation.wallet.manager.key.CryptoProviderManager
+import com.flowfoundation.wallet.manager.key.KeyCompatibilityManager
 import com.flowfoundation.wallet.manager.nft.NftCollectionStateManager
 import com.flowfoundation.wallet.manager.staking.StakingManager
 import com.flowfoundation.wallet.manager.token.FungibleTokenListManager
@@ -108,10 +109,9 @@ suspend fun registerOutblock(
                     // Now that we have the wallet data with account address, use fetchAccountByAddress 
                     // to populate the wallet SDK with the account details from Flow network
                     val storage = FileSystemStorage(File(Env.getApp().filesDir, "wallet"))
-                    val keyForWalletSDK = try {
-                        PrivateKey.get("prefix_key_$prefix", prefix, storage)
-                    } catch (e: Exception) {
-                        logd(TAG, "Failed to retrieve stored private key for Wallet SDK init.")
+                    val keyForWalletSDK = KeyCompatibilityManager.getPrivateKeyWithFallback(prefix, storage)
+                    if (keyForWalletSDK == null) {
+                        logd(TAG, "Failed to retrieve stored private key for Wallet SDK init from both new and old storage.")
                         continuation.resume(false)
                         return@ioScope
                     }

--- a/app/src/main/java/com/flowfoundation/wallet/page/restore/multirestore/viewmodel/MultiRestoreViewModel.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/page/restore/multirestore/viewmodel/MultiRestoreViewModel.kt
@@ -15,6 +15,7 @@ import com.flowfoundation.wallet.manager.flowjvm.CadenceArgumentsBuilder
 import com.flowfoundation.wallet.manager.flowjvm.CadenceScript
 import com.flowfoundation.wallet.manager.flowjvm.addPlatformInfo
 import com.flowfoundation.wallet.manager.key.HDWalletCryptoProvider
+import com.flowfoundation.wallet.manager.key.KeyCompatibilityManager
 import com.flowfoundation.wallet.manager.transaction.OnTransactionStateChange
 import com.flowfoundation.wallet.manager.transaction.TransactionState
 import com.flowfoundation.wallet.manager.transaction.TransactionStateManager
@@ -415,11 +416,8 @@ class MultiRestoreViewModel : ViewModel(), OnTransactionStateChange {
                     throw RuntimeException("Stored key information is missing - cannot proceed with syncAccountInfo")
                 }
 
-                val newPrivateKey = try {
-                    PrivateKey.get(storedKeyId, storedPrefix, storage)
-                } catch (e: Exception) {
-                    throw RuntimeException("Failed to load the stored key that was added to the account: ${e.message}", e)
-                }
+                val newPrivateKey = KeyCompatibilityManager.getPrivateKeyWithFallback(storedPrefix, storage)
+                    ?: throw RuntimeException("Failed to load the stored key that was added to the account from both new and old storage")
 
                 val newPublicKey = newPrivateKey.publicKey(storedSigningAlgorithm)?.toHexString()?.removePrefix("04") ?: ""
                 logd("MultiRestore", "Using stored key for syncAccountInfo: ${newPublicKey.take(20)}... (algorithms: signing=${storedSigningAlgorithm}, hashing=${storedHashingAlgorithm})")


### PR DESCRIPTION
## Related Issue
Closes #1394 
<!-- If this PR addresses an issue, link it here (e.g., "Closes #123") -->
- Migrates keystore into new format on app startup, if user is still using old keystore logic

The migration runs automatically when:
- App startup - During AccountManager.init()
- Account migration - During accountMigrateV1()

## Summary of Changes
<!-- Provide a concise description of the changes made in this PR. 
What functionality was added, updated, or fixed? -->

## Need Regression Testing
<!-- Indicate whether this PR requires regression testing and why. -->
- [ ] Yes
- [ ] No

## Risk Assessment
<!-- Assess the risk level of this PR:
- Low: Minimal impact, straightforward changes.
- Medium: Potential for some edge cases or indirect effects.
- High: Could affect critical functionality or many users.
-->
- [ ] Low
- [ ] Medium
- [ ] High

## Additional Notes
<!-- Add any other context or comments about the PR here -->

## Screenshots (if applicable)
<!-- Attach any screenshots that help explain your changes -->
