### PR TITLE
1627 - fix: bubble item

### DIFF
--- a/app/src/main/java/com/flowfoundation/wallet/page/window/bubble/model/BubbleItem.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/page/window/bubble/model/BubbleItem.kt
@@ -29,7 +29,7 @@ fun BubbleItem.icon(): Any? {
 fun BubbleItem.title(): String {
     return when (data) {
         is BrowserTab -> data.title().orEmpty()
-        is TransactionState -> title()
+        is TransactionState -> transactionTitle()
         else -> ""
     }
 }
@@ -46,6 +46,6 @@ private fun TransactionState.icon(): Any {
     }
 }
 
-private fun title(): String {
+private fun transactionTitle(): String {
     return R.string.pending_transaction.res2String()
 }

--- a/app/src/main/java/com/flowfoundation/wallet/page/window/bubble/model/BubbleItem.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/page/window/bubble/model/BubbleItem.kt
@@ -29,7 +29,7 @@ fun BubbleItem.icon(): Any? {
 fun BubbleItem.title(): String {
     return when (data) {
         is BrowserTab -> data.title().orEmpty()
-        is TransactionState -> transactionTitle()
+        is TransactionState -> data.title()
         else -> ""
     }
 }
@@ -46,6 +46,6 @@ private fun TransactionState.icon(): Any {
     }
 }
 
-private fun transactionTitle(): String {
+private fun TransactionState.title(): String {
     return R.string.pending_transaction.res2String()
 }


### PR DESCRIPTION
## Related Issue
<!-- If this PR addresses an issue, link it here (e.g., "Closes #123") -->
Closes https://github.com/onflow/FRW-Android/issues/1627

## Summary of Changes
<!-- Provide a concise description of the changes made in this PR. 
What functionality was added, updated, or fixed? -->


In [BubbleItem.kt:32], the BubbleItem.title() extension function was incorrectly calling itself when handling TransactionState data:
```
fun BubbleItem.title(): String {
    return when (data) {
        is BrowserTab -> data.title().orEmpty()
        is TransactionState -> title()  // ❌ Infinite recursion!
        else -> ""
    }
}
```

## Need Regression Testing
<!-- Indicate whether this PR requires regression testing and why. -->
- [ ] Yes
- [ ] No

## Risk Assessment
<!-- Assess the risk level of this PR:
- Low: Minimal impact, straightforward changes.
- Medium: Potential for some edge cases or indirect effects.
- High: Could affect critical functionality or many users.
-->
- [ ] Low
- [ ] Medium
- [ ] High

## Additional Notes
<!-- Add any other context or comments about the PR here -->

## Screenshots (if applicable)
<!-- Attach any screenshots that help explain your changes -->
