### PR TITLE
900 - re-implement missing native recovery screen entry points

### DIFF
--- a/app/src/main/java/com/flowfoundation/wallet/reactnative/bridge/NativeScreen.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/reactnative/bridge/NativeScreen.kt
@@ -4,11 +4,20 @@ package com.flowfoundation.wallet.reactnative.bridge
  * Enum representing native Android screens that can be launched from React Native
  */
 enum class NativeScreen(val screenName: String) {
+    // Backup screens
     MULTI_BACKUP("multiBackup"),
     DEVICE_BACKUP("deviceBackup"),
     SEED_PHRASE_BACKUP("seedPhraseBackup"),
     BACKUP_OPTIONS("backupOptions"),
-    WALLET_RESTORE("walletRestore");
+
+    // Restore screens
+    WALLET_RESTORE("walletRestore"),
+    RECOVERY_PHRASE_RESTORE("recoveryPhraseRestore"),
+    KEY_STORE_RESTORE("keyStoreRestore"),
+    PRIVATE_KEY_RESTORE("privateKeyRestore"),
+    GOOGLE_DRIVE_RESTORE("googleDriveRestore"),
+    ICLOUD_RESTORE("icloudRestore"),
+    MULTI_RESTORE("multiRestore");
 
     companion object {
         fun fromString(value: String): NativeScreen? {

--- a/app/src/main/java/com/flowfoundation/wallet/reactnative/bridge/NativeScreen.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/reactnative/bridge/NativeScreen.kt
@@ -16,7 +16,6 @@ enum class NativeScreen(val screenName: String) {
     KEY_STORE_RESTORE("keyStoreRestore"),
     PRIVATE_KEY_RESTORE("privateKeyRestore"),
     GOOGLE_DRIVE_RESTORE("googleDriveRestore"),
-    ICLOUD_RESTORE("icloudRestore"),
     MULTI_RESTORE("multiRestore");
 
     companion object {

--- a/app/src/main/java/com/flowfoundation/wallet/reactnative/bridge/handlers/UIBridgeHandler.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/reactnative/bridge/handlers/UIBridgeHandler.kt
@@ -238,13 +238,6 @@ class UIBridgeHandler(private val reactContext: ReactApplicationContext) {
                     logd(TAG, "launchNativeScreen() - launched GoogleDriveRestoreActivity (Google Drive)")
                 }
 
-                NativeScreen.ICLOUD_RESTORE -> {
-                    // iCloud restore not supported on Android, launch MultiRestoreActivity instead
-                    // which provides Google Drive and other cloud options
-                    MultiRestoreActivity.launch(currentActivity)
-                    logd(TAG, "launchNativeScreen() - iCloud requested on Android, launched MultiRestoreActivity instead")
-                }
-
                 NativeScreen.MULTI_RESTORE -> {
                     // Launch MultiRestoreActivity (Multi-restore with all cloud backup options)
                     MultiRestoreActivity.launch(currentActivity)

--- a/app/src/main/java/com/flowfoundation/wallet/reactnative/bridge/handlers/UIBridgeHandler.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/reactnative/bridge/handlers/UIBridgeHandler.kt
@@ -9,6 +9,9 @@ import com.flowfoundation.wallet.page.backup.WalletBackupActivity
 import com.flowfoundation.wallet.page.backup.device.CreateDeviceBackupActivity
 import com.flowfoundation.wallet.page.backup.multibackup.MultiBackupActivity
 import com.flowfoundation.wallet.page.restore.WalletRestoreActivity
+import com.flowfoundation.wallet.page.restore.keystore.KeyStoreRestoreActivity
+import com.flowfoundation.wallet.page.restore.mnemonic.RestoreMnemonicActivity
+import com.flowfoundation.wallet.page.restore.multirestore.MultiRestoreActivity
 import com.flowfoundation.wallet.page.scan.ScanBarcodeActivity
 import com.flowfoundation.wallet.reactnative.bridge.QRCodeScanManager
 import com.flowfoundation.wallet.reactnative.bridge.NativeScreen
@@ -209,6 +212,43 @@ class UIBridgeHandler(private val reactContext: ReactApplicationContext) {
                     intent.putExtra("launchedFromRN", true)
                     currentActivity.startActivity(intent)
                     logd(TAG, "launchNativeScreen() - launched WalletRestoreActivity with restore options from RN")
+                }
+
+                NativeScreen.RECOVERY_PHRASE_RESTORE -> {
+                    // Launch RestoreMnemonicActivity (Restore from 12-word recovery phrase)
+                    RestoreMnemonicActivity.launch(currentActivity)
+                    logd(TAG, "launchNativeScreen() - launched RestoreMnemonicActivity")
+                }
+
+                NativeScreen.KEY_STORE_RESTORE -> {
+                    // Launch KeyStoreRestoreActivity (Restore from key store file)
+                    KeyStoreRestoreActivity.launchKeyStore(currentActivity)
+                    logd(TAG, "launchNativeScreen() - launched KeyStoreRestoreActivity (key store mode)")
+                }
+
+                NativeScreen.PRIVATE_KEY_RESTORE -> {
+                    // Launch KeyStoreRestoreActivity in private key mode
+                    KeyStoreRestoreActivity.launchPrivateKey(currentActivity)
+                    logd(TAG, "launchNativeScreen() - launched KeyStoreRestoreActivity (private key mode)")
+                }
+
+                NativeScreen.GOOGLE_DRIVE_RESTORE -> {
+                    // Launch MultiRestoreActivity (Cloud restore: Google Drive, Dropbox, etc.)
+                    MultiRestoreActivity.launch(currentActivity)
+                    logd(TAG, "launchNativeScreen() - launched MultiRestoreActivity (Google Drive)")
+                }
+
+                NativeScreen.ICLOUD_RESTORE -> {
+                    // iCloud restore not supported on Android, launch MultiRestoreActivity instead
+                    // which provides Google Drive and other cloud options
+                    MultiRestoreActivity.launch(currentActivity)
+                    logd(TAG, "launchNativeScreen() - iCloud requested on Android, launched MultiRestoreActivity instead")
+                }
+
+                NativeScreen.MULTI_RESTORE -> {
+                    // Launch MultiRestoreActivity (Multi-restore with all cloud backup options)
+                    MultiRestoreActivity.launch(currentActivity)
+                    logd(TAG, "launchNativeScreen() - launched MultiRestoreActivity")
                 }
             }
         } catch (e: Exception) {

--- a/app/src/main/java/com/flowfoundation/wallet/reactnative/bridge/handlers/UIBridgeHandler.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/reactnative/bridge/handlers/UIBridgeHandler.kt
@@ -9,6 +9,9 @@ import com.flowfoundation.wallet.page.backup.WalletBackupActivity
 import com.flowfoundation.wallet.page.backup.device.CreateDeviceBackupActivity
 import com.flowfoundation.wallet.page.backup.multibackup.MultiBackupActivity
 import com.flowfoundation.wallet.page.restore.WalletRestoreActivity
+import com.flowfoundation.wallet.page.restore.keystore.KeyStoreRestoreActivity
+import com.flowfoundation.wallet.page.restore.multirestore.MultiRestoreActivity
+import com.flowfoundation.wallet.page.walletrestore.WalletRestoreActivity as GoogleDriveRestoreActivity
 import com.flowfoundation.wallet.page.scan.ScanBarcodeActivity
 import com.flowfoundation.wallet.reactnative.bridge.QRCodeScanManager
 import com.flowfoundation.wallet.reactnative.bridge.NativeScreen
@@ -209,6 +212,43 @@ class UIBridgeHandler(private val reactContext: ReactApplicationContext) {
                     intent.putExtra("launchedFromRN", true)
                     currentActivity.startActivity(intent)
                     logd(TAG, "launchNativeScreen() - launched WalletRestoreActivity with restore options from RN")
+                }
+
+                NativeScreen.RECOVERY_PHRASE_RESTORE -> {
+                    // Launch KeyStoreRestoreActivity in seed phrase mode (Restore from 12-word recovery phrase)
+                    KeyStoreRestoreActivity.launchSeedPhrase(currentActivity)
+                    logd(TAG, "launchNativeScreen() - launched KeyStoreRestoreActivity (seed phrase mode)")
+                }
+
+                NativeScreen.KEY_STORE_RESTORE -> {
+                    // Launch KeyStoreRestoreActivity (Restore from key store file)
+                    KeyStoreRestoreActivity.launchKeyStore(currentActivity)
+                    logd(TAG, "launchNativeScreen() - launched KeyStoreRestoreActivity (key store mode)")
+                }
+
+                NativeScreen.PRIVATE_KEY_RESTORE -> {
+                    // Launch KeyStoreRestoreActivity in private key mode
+                    KeyStoreRestoreActivity.launchPrivateKey(currentActivity)
+                    logd(TAG, "launchNativeScreen() - launched KeyStoreRestoreActivity (private key mode)")
+                }
+
+                NativeScreen.GOOGLE_DRIVE_RESTORE -> {
+                    // Launch GoogleDriveRestoreActivity (Google Drive restore flow)
+                    GoogleDriveRestoreActivity.launch(currentActivity)
+                    logd(TAG, "launchNativeScreen() - launched GoogleDriveRestoreActivity (Google Drive)")
+                }
+
+                NativeScreen.ICLOUD_RESTORE -> {
+                    // iCloud restore not supported on Android, launch MultiRestoreActivity instead
+                    // which provides Google Drive and other cloud options
+                    MultiRestoreActivity.launch(currentActivity)
+                    logd(TAG, "launchNativeScreen() - iCloud requested on Android, launched MultiRestoreActivity instead")
+                }
+
+                NativeScreen.MULTI_RESTORE -> {
+                    // Launch MultiRestoreActivity (Multi-restore with all cloud backup options)
+                    MultiRestoreActivity.launch(currentActivity)
+                    logd(TAG, "launchNativeScreen() - launched MultiRestoreActivity")
                 }
             }
         } catch (e: Exception) {


### PR DESCRIPTION
Restore the Android native implementations for recovery/restore screen entry points that were lost during the refactoring from monolithic NativeFRWBridge to handler-based architecture.

## Changes

### NativeScreen.kt
- Add missing restore screen enum values:
  - RECOVERY_PHRASE_RESTORE
  - KEY_STORE_RESTORE
  - PRIVATE_KEY_RESTORE
  - GOOGLE_DRIVE_RESTORE
  - MULTI_RESTORE



Closes #900

## Related Issue
<!-- If this PR addresses an issue, link it here (e.g., "Closes #123") -->
Closes #???

## Summary of Changes
<!-- Provide a concise description of the changes made in this PR. 
What functionality was added, updated, or fixed? -->

## Need Regression Testing
<!-- Indicate whether this PR requires regression testing and why. -->
- [ ] Yes
- [ ] No

## Risk Assessment
<!-- Assess the risk level of this PR:
- Low: Minimal impact, straightforward changes.
- Medium: Potential for some edge cases or indirect effects.
- High: Could affect critical functionality or many users.
-->
- [ ] Low
- [ ] Medium
- [ ] High

## Additional Notes
<!-- Add any other context or comments about the PR here -->

## Screenshots (if applicable)
<!-- Attach any screenshots that help explain your changes -->
