### PR TITLE
Guard WebViewActivity against MissingWebViewPackageException

### DIFF
--- a/app/src/main/java/com/flowfoundation/wallet/page/common/WebViewActivity.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/page/common/WebViewActivity.kt
@@ -3,10 +3,14 @@ package com.flowfoundation.wallet.page.common
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.util.AndroidRuntimeException
 import android.view.MenuItem
+import android.widget.Toast
 import com.flowfoundation.wallet.R
 import com.flowfoundation.wallet.base.activity.BaseActivity
 import com.flowfoundation.wallet.page.browser.widgets.LilicoWebView
+import com.flowfoundation.wallet.utils.loge
+import com.flowfoundation.wallet.utils.toast
 
 class WebViewActivity : BaseActivity() {
 
@@ -14,9 +18,24 @@ class WebViewActivity : BaseActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_webview)
-        findViewById<LilicoWebView>(R.id.webview).apply {
-            loadUrl(this@WebViewActivity.url!!)
+        // Inflating the WebView can throw AndroidRuntimeException wrapping
+        // WebViewFactory$MissingWebViewPackageException on devices where the
+        // Android System WebView package is missing, disabled, or being updated.
+        // Crashing the activity in that case (issue #1256) leaves the user
+        // with no recourse. Catch it, surface a clear message and finish.
+        try {
+            setContentView(R.layout.activity_webview)
+            findViewById<LilicoWebView>(R.id.webview).apply {
+                loadUrl(this@WebViewActivity.url!!)
+            }
+        } catch (e: AndroidRuntimeException) {
+            loge(e)
+            toast(R.string.webview_unavailable, Toast.LENGTH_LONG)
+            finish()
+        } catch (e: Exception) {
+            loge(e)
+            toast(R.string.webview_unavailable, Toast.LENGTH_LONG)
+            finish()
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -830,4 +830,5 @@
     <string name="confirm_copy_address_tips">You have copied an EVM address on the Flow network, please make sure you only send assets on the Flow network to this address otherwise they will be lost.</string>
     <string name="evm_on_flow_address">EVM on Flow address</string>
     <string name="recover_profile">Recover profile</string>
+    <string name="webview_unavailable">Android System WebView is unavailable on this device. Please install or enable it from the Play Store and try again.</string>
 </resources>


### PR DESCRIPTION
Closes #1256

### What is happening

`WebViewActivity.onCreate` calls `setContentView(R.layout.activity_webview)` and then `loadUrl` on the inflated `LilicoWebView`. On a small but nonzero share of devices the system WebView package is missing, disabled, or partially updated, and inflating any view that depends on it throws `android.util.AndroidRuntimeException: java.lang.RuntimeException: Cannot load WebView`. Because `onCreate` lets the exception escape, the process crashes and the user sees a generic Android error dialog with no idea what to do about it.

The Firebase report linked in #1256 has this exact stack trace, with the failure originating from `MissingWebViewPackageException` inside the platform code.

### What this PR does

It wraps the inflate and `loadUrl` calls in a small try/catch. When the WebView package is missing the activity logs the error, shows a localized toast pointing the user at the Play Store entry for Android System WebView, and finishes itself instead of crashing. The same handler also catches the broader `Exception` so future variants of the same problem do not slip through.

The new string `webview_unavailable` is added to `values/strings.xml` only. Translators can pick it up later through the normal localization flow.
