### PR TITLE
Destroy LilicoWebView when tabs and WebViewActivity tear down

### DIFF
--- a/app/src/main/java/com/flowfoundation/wallet/page/browser/tools/BrowserTabs.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/page/browser/tools/BrowserTabs.kt
@@ -11,6 +11,7 @@ import com.flowfoundation.wallet.page.browser.widgets.LilicoWebView
 import com.flowfoundation.wallet.page.window.WindowFrame
 import com.flowfoundation.wallet.utils.extensions.removeFromParent
 import com.flowfoundation.wallet.utils.extensions.setVisible
+import com.flowfoundation.wallet.utils.loge
 import java.util.*
 
 private val tabs = mutableListOf<BrowserTab>()
@@ -24,6 +25,7 @@ fun popBrowserTab(tabId: String) {
     tab.webView.saveRecentRecord()
 
     webViewContainer.removeWebView(tab.webView)
+    tab.webView.destroyWebView()
 
     if (tabs.isEmpty()) {
         releaseBrowser()
@@ -72,6 +74,11 @@ fun newAndPushBrowserTab(url: String? = null): BrowserTab? {
 }
 
 fun clearBrowserTabs() {
+    // Destroy each WebView before dropping the references. Without this the
+    // chromium-side resources (renderer process, GPU buffers, JS heap) stay
+    // alive until the GC happens to collect the wrapper, which is a major
+    // contributor to the OOM reports filed against ExploreFragment.
+    tabs.forEach { runCatching { it.webView.destroyWebView() }.onFailure { loge(it) } }
     tabs.clear()
 }
 
@@ -98,6 +105,23 @@ private fun ViewGroup.removeWebView(webView: WebView) {
 
 private fun cleanCallbacks() {
     tabs.forEach { it.webView.setWebViewCallback(null) }
+}
+
+/**
+ * Standard cleanup sequence recommended by the Android WebView team. Skipping
+ * any of these steps tends to leave the renderer process or the chromium JS
+ * heap allocated, which shows up later as an OOM in an unrelated allocation.
+ */
+private fun LilicoWebView.destroyWebView() {
+    runCatching {
+        stopLoading()
+        setWebViewCallback(null)
+        loadUrl("about:blank")
+        clearHistory()
+        removeFromParent()
+        removeAllViews()
+        destroy()
+    }.onFailure { loge(it) }
 }
 
 class BrowserTab(

--- a/app/src/main/java/com/flowfoundation/wallet/page/common/WebViewActivity.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/page/common/WebViewActivity.kt
@@ -7,6 +7,8 @@ import android.view.MenuItem
 import com.flowfoundation.wallet.R
 import com.flowfoundation.wallet.base.activity.BaseActivity
 import com.flowfoundation.wallet.page.browser.widgets.LilicoWebView
+import com.flowfoundation.wallet.utils.extensions.removeFromParent
+import com.flowfoundation.wallet.utils.loge
 
 class WebViewActivity : BaseActivity() {
 
@@ -18,6 +20,25 @@ class WebViewActivity : BaseActivity() {
         findViewById<LilicoWebView>(R.id.webview).apply {
             loadUrl(this@WebViewActivity.url!!)
         }
+    }
+
+    override fun onDestroy() {
+        // Without an explicit destroy the chromium-side resources backing the
+        // WebView outlive this Activity and accumulate across launches. That
+        // leak is one of the contributors to the OOM crashes reported against
+        // browser-adjacent screens.
+        runCatching {
+            findViewById<LilicoWebView>(R.id.webview)?.let { web ->
+                web.stopLoading()
+                web.setWebViewCallback(null)
+                web.loadUrl("about:blank")
+                web.clearHistory()
+                web.removeFromParent()
+                web.removeAllViews()
+                web.destroy()
+            }
+        }.onFailure { loge(it) }
+        super.onDestroy()
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {


### PR DESCRIPTION
### Background

`BrowserTabs.kt` keeps a process-wide `mutableListOf<BrowserTab>()` where each tab owns a `LilicoWebView`. Two things happen to that list as the user uses the in-app dApp browser:

1. `popBrowserTab` removes the tab entry and detaches the WebView from its parent container, but it never calls `destroy()` on the WebView.
2. `clearBrowserTabs` (invoked from `releaseBrowser` when the user leaves the browser, and from a few other places) just runs `tabs.clear()` and does not destroy the WebViews either.

`WebViewActivity` has the same gap. The activity holds a `LilicoWebView` through the inflated layout for its full lifetime and never calls `destroy` on `onDestroy`.

A `WebView` is mostly a thin Java handle on top of a chromium renderer process, a JS heap, GPU buffers, and a pile of native parcel buffers. None of that is freed until `destroy()` is called. Until then the GC cannot reclaim the wrapper either, because the platform keeps internal references back into it. So every dApp the user opens leaks a renderer worth of memory, and the leak persists across the user backing out of the browser, switching wallets, or closing tabs.

### Why this matches the open OOM reports

Several open issues report `OutOfMemoryError` from very different call sites: ExploreFragment, FclSignMessageDialog, EVMSignMessageDialog, generic 16 to 64 byte allocation failures inside `Parcel.nativeCreate`, RxJava `OnErrorNotImplementedException` wrappers around OOM, and so on. The common thread is that none of those allocation sites are large by themselves, they only fail when the process heap is already saturated. A leaking WebView per browser session is a very plausible cause of that saturation, and the fact that the failures cluster on devices with a long browser usage session is consistent with that pattern.

This PR is not a claim that every one of those reports is fully explained by this single leak, but stopping the leak removes the most obvious systemic source of pressure and should reduce the rate noticeably.

Related reports that should benefit:
* #978, #979, #980, #981, #982, #985, #1013, #1029, #1039, #1048, #1049, #986

### Changes

* Added a private `LilicoWebView.destroyWebView()` extension in `BrowserTabs.kt`. It runs the standard cleanup recommended by the Android team inside `runCatching`: stop loading, drop the webview callback, navigate to `about:blank`, clear history, detach from any parent, drop child views, then `destroy`.
* Called `destroyWebView()` from `popBrowserTab` after the existing `removeWebView` call.
* Called `destroyWebView()` for every tab inside `clearBrowserTabs` before `tabs.clear()` runs.
* Overrode `onDestroy` in `WebViewActivity` to apply the same cleanup, so the standalone activity stops leaking too.
