### PR TITLE
feat(services): Recover legacy Android Keystore account mappings

### DIFF
--- a/app/src/androidTest/java/com/flowfoundation/wallet/manager/account/KeyStoreMigrationManagerAndroidTest.kt
+++ b/app/src/androidTest/java/com/flowfoundation/wallet/manager/account/KeyStoreMigrationManagerAndroidTest.kt
@@ -1,0 +1,61 @@
+package com.flowfoundation.wallet.manager.account
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.flow.wallet.KeyManager
+import java.security.KeyPairGenerator
+import java.security.KeyStore
+import java.security.interfaces.ECPublicKey
+import java.security.spec.ECGenParameterSpec
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class KeyStoreMigrationManagerAndroidTest {
+
+    @Test
+    fun realAndroidKeystoreCertificateParticipatesInDiscovery() = runBlocking {
+        val aliasPrefix = KeyManager.KEYSTORE_ALIAS_PREFIX + "recovery_test_"
+        val alias = aliasPrefix + "alpha"
+        val keyStore = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+        keyStore.deleteEntry(alias)
+
+        try {
+            val pair = KeyPairGenerator.getInstance(
+                KeyProperties.KEY_ALGORITHM_EC,
+                "AndroidKeyStore",
+            ).apply {
+                initialize(
+                    KeyGenParameterSpec.Builder(alias, KeyProperties.PURPOSE_SIGN)
+                        .setAlgorithmParameterSpec(ECGenParameterSpec("secp256r1"))
+                        .setDigests(KeyProperties.DIGEST_SHA256)
+                        .build()
+                )
+            }.generateKeyPair()
+            val expected = KeyStoreMigrationManager.flowPublicKey(pair.public as ECPublicKey)!!
+
+            val discovery = KeyStoreMigrationManager.discoverOrphanedKeystoreKeys(
+                knownAddresses = setOf("0x01"),
+                aliasPrefix = aliasPrefix,
+                keystore = KeyStoreMigrationManager.androidKeystoreSource(),
+                onChainKeys = KeyStoreMigrationManager.OnChainKeySource {
+                    listOf(
+                        KeyStoreMigrationManager.OnChainKey(expected, revoked = false)
+                    )
+                },
+            )
+
+            assertTrue(discovery.isComplete)
+            assertEquals(
+                listOf(KeyStoreMigrationManager.RecoveryMatch("alpha", "0x01", expected)),
+                discovery.matches,
+            )
+        } finally {
+            keyStore.deleteEntry(alias)
+        }
+    }
+}

--- a/app/src/main/java/com/flowfoundation/wallet/manager/account/AccountManager.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/manager/account/AccountManager.kt
@@ -132,6 +132,26 @@ object AccountManager {
                 // Update Accounts info with WalletDataManager
                 WalletDataManager.updateWalletData()
 
+                // Legacy Keystore discovery performs network I/O for locally known addresses.
+                // Keep it off the initialization path, then publish all recovered mappings once.
+                ioScope {
+                    val discovery = KeyStoreMigrationManager.discoverOrphanedKeystoreKeys()
+                    val publication = applyRecoveredKeystoreKeys(discovery.matches)
+                    if (publication.updatedAccountCount > 0) {
+                        logd(
+                            TAG,
+                            "Recovered Keystore mappings for " +
+                                "${publication.updatedAccountCount} account(s)"
+                        )
+                    }
+                    discovery.failures.forEach { failure ->
+                        loge(
+                            TAG,
+                            "Keystore recovery incomplete for ${failure.target}: ${failure.message}"
+                        )
+                    }
+                }
+
             } catch (e: Exception) {
                 loge(TAG, "AccountManager initialization failed: $e")
                 ErrorReporter.reportWithMixpanel(AccountError.INIT_FAILED, e)
@@ -364,6 +384,7 @@ object AccountManager {
         }
     }
 
+    @Synchronized
     fun updateAccountList(accountList: List<Account>) {
         if (accountList.isEmpty()) return
 
@@ -371,10 +392,15 @@ object AccountManager {
         accountList.forEach { newAccount ->
             val index = accounts.indexOfFirst { it.userInfo.username == newAccount.userInfo.username }
             if (index != -1) {
-                accounts[index] = newAccount
-                if (currentAccount?.userInfo?.username == newAccount.userInfo.username) {
-                    currentAccount = newAccount
-                    dispatchListeners(newAccount)
+                // Wallet refreshes must not overwrite a local custody mapping recovered in
+                // parallel from Android Keystore.
+                val mergedAccount = newAccount.copy(
+                    prefix = accounts[index].prefix ?: newAccount.prefix
+                )
+                accounts[index] = mergedAccount
+                if (currentAccount?.userInfo?.username == mergedAccount.userInfo.username) {
+                    currentAccount = mergedAccount
+                    dispatchListeners(mergedAccount)
                 }
                 hasChanges = true
             }
@@ -385,6 +411,128 @@ object AccountManager {
             dispatchListListeners(accounts)
         }
     }
+
+    internal data class RecoveryPublication(
+        val updatedAccountCount: Int,
+        val unresolvedMatches: List<KeyStoreMigrationManager.RecoveryMatch>,
+    )
+
+    /**
+     * Applies discovery results to existing real accounts and publishes one accumulated snapshot.
+     * The scanner never mutates account state itself.
+     */
+    internal fun applyRecoveredKeystoreKeys(
+        matches: List<KeyStoreMigrationManager.RecoveryMatch>,
+    ): RecoveryPublication {
+        if (matches.isEmpty()) {
+            return RecoveryPublication(0, emptyList())
+        }
+
+        data class ResolvedAccount(
+            val index: Int,
+            val account: Account,
+            val uid: String,
+            val prefix: String,
+        )
+
+        val publicationState = synchronized(this) {
+            val unresolved = matches.toMutableSet()
+            val resolved = accounts.mapIndexedNotNull { index, account ->
+                val addresses = KeyStoreMigrationManager.locallyKnownFlowAddresses(account)
+                    .mapTo(linkedSetOf()) { address ->
+                        KeyStoreMigrationManager.normalizeAddress(address)
+                    }
+                val accountMatches = matches.filter { match ->
+                    KeyStoreMigrationManager.normalizeAddress(match.address) in addresses
+                }
+                if (accountMatches.isEmpty()) return@mapIndexedNotNull null
+
+                val uid = account.wallet?.id?.takeIf { it.isNotBlank() }
+                if (uid == null) return@mapIndexedNotNull null
+
+                val candidatePrefixes = accountMatches.map { it.prefix }.distinct()
+                val selectedPrefix = when {
+                    account.prefix in candidatePrefixes -> account.prefix
+                    candidatePrefixes.size == 1 -> candidatePrefixes.single()
+                    else -> null
+                } ?: return@mapIndexedNotNull null
+
+                unresolved.removeAll(accountMatches.toSet())
+                ResolvedAccount(index, account, uid, selectedPrefix)
+            }
+
+            val recoveredUids = resolved.mapTo(linkedSetOf()) { it.uid }
+            val newPrefixes = userPrefixes
+                .filterNot { it.userId in recoveredUids }
+                .toMutableList()
+                .apply {
+                    addAll(resolved.map { UserPrefix(it.uid, it.prefix) })
+                }
+
+            var updatedAccountCount = 0
+            var activeAccountUpdate: Account? = null
+            resolved.forEach { recovered ->
+                val mappingWasComplete = recovered.account.prefix == recovered.prefix &&
+                    userPrefixes.count {
+                        it.userId == recovered.uid && it.prefix == recovered.prefix
+                    } == 1 &&
+                    userPrefixes.none {
+                        it.userId == recovered.uid && it.prefix != recovered.prefix
+                    }
+                if (!mappingWasComplete) updatedAccountCount++
+
+                if (recovered.account.prefix != recovered.prefix) {
+                    val updated = recovered.account.copy(prefix = recovered.prefix)
+                    accounts[recovered.index] = updated
+                    if (currentAccount?.wallet?.id == recovered.uid) {
+                        currentAccount = updated
+                        activeAccountUpdate = updated
+                    }
+                }
+            }
+
+            val prefixStateChanged = newPrefixes != userPrefixes
+            if (prefixStateChanged) {
+                userPrefixes.clear()
+                userPrefixes.addAll(newPrefixes)
+            }
+
+            val stateChanged = updatedAccountCount > 0 || prefixStateChanged
+            RecoveryPublicationState(
+                accountSnapshot = accounts.toList(),
+                prefixSnapshot = userPrefixes.toList(),
+                activeAccountUpdate = activeAccountUpdate,
+                updatedAccountCount = updatedAccountCount,
+                unresolvedMatches = unresolved.toList(),
+                stateChanged = stateChanged,
+            )
+        }
+
+        if (publicationState.stateChanged) {
+            AccountCacheManager.cache(
+                Accounts().apply { addAll(publicationState.accountSnapshot) }
+            )
+            UserPrefixCacheManager.cache(
+                UserPrefixes().apply { addAll(publicationState.prefixSnapshot) }
+            )
+            publicationState.activeAccountUpdate?.let(::dispatchListeners)
+            dispatchListListeners(publicationState.accountSnapshot)
+        }
+
+        return RecoveryPublication(
+            updatedAccountCount = publicationState.updatedAccountCount,
+            unresolvedMatches = publicationState.unresolvedMatches,
+        )
+    }
+
+    private data class RecoveryPublicationState(
+        val accountSnapshot: List<Account>,
+        val prefixSnapshot: List<UserPrefix>,
+        val activeAccountUpdate: Account?,
+        val updatedAccountCount: Int,
+        val unresolvedMatches: List<KeyStoreMigrationManager.RecoveryMatch>,
+        val stateChanged: Boolean,
+    )
 
     fun addListener(callback: OnAccountUpdate) {
         uiScope { listeners.add(WeakReference(callback)) }
@@ -834,4 +982,3 @@ interface OnAccountListUpdate {
 interface OnUserInfoReload {
     fun onUserInfoReload()
 }
-

--- a/app/src/main/java/com/flowfoundation/wallet/manager/account/KeyStoreMigrationManager.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/manager/account/KeyStoreMigrationManager.kt
@@ -1,41 +1,269 @@
 package com.flowfoundation.wallet.manager.account
 
+import com.flow.wallet.KeyManager
+import com.flowfoundation.wallet.manager.app.chainNetWorkString
+import com.flowfoundation.wallet.manager.flow.FlowCadenceApi
+import com.flowfoundation.wallet.manager.walletdata.FlowWallet
 import com.flowfoundation.wallet.utils.logd
+import com.flowfoundation.wallet.utils.loge
 import java.security.KeyStore
+import java.security.interfaces.ECPublicKey
 
 /**
- * Manages migration of private keys from the old Android Keystore system
- * to the new Flow-Wallet-Kit storage system.
+ * Discovers legacy Flow keys that still exist in Android Keystore but are no longer mapped to
+ * their locally known accounts.
  *
- * This is critical for users upgrading from versions that used direct Android Keystore access
- * to versions that use the Flow-Wallet-Kit storage abstraction.
- *
+ * Recovery is deliberately limited to Flow addresses already discoverable from local account
+ * state. This scanner only returns evidence; [AccountManager] owns all account mutations,
+ * persistence, and UI publication.
  */
 object KeyStoreMigrationManager {
     private const val TAG = "KeyStoreMigration"
 
+    data class RecoveryMatch(
+        val prefix: String,
+        val address: String,
+        val publicKey: String,
+    )
+
+    data class RecoveryFailure(
+        val target: String,
+        val message: String,
+    )
+
+    data class RecoveryDiscovery(
+        val matches: List<RecoveryMatch>,
+        val failures: List<RecoveryFailure>,
+        val isComplete: Boolean,
+    )
+
+    internal data class OnChainKey(
+        val publicKey: String,
+        val revoked: Boolean,
+    )
+
+    internal fun interface OnChainKeySource {
+        suspend fun keys(address: String): List<OnChainKey>
+    }
+
+    internal interface LegacyKeystoreSource {
+        fun aliases(): List<String>
+        fun publicKey(alias: String): ECPublicKey?
+    }
+
     /**
-     * Diagnostic function to list all keys in Android Keystore
+     * Diagnostic function to list all keys in Android Keystore.
      */
     fun diagnoseAndroidKeystore(): List<String> {
         return try {
-            val keyStore = KeyStore.getInstance("AndroidKeyStore")
-            keyStore.load(null)
-
-            val aliases = mutableListOf<String>()
-            val enumeration = keyStore.aliases()
-            while (enumeration.hasMoreElements()) {
-                val alias = enumeration.nextElement()
-                aliases.add(alias)
+            AndroidLegacyKeystoreSource().aliases().onEach { alias ->
                 logd(TAG, "Found alias in Android Keystore: $alias")
             }
-
-            logd(TAG, "Total aliases in Android Keystore: ${aliases.size}")
-            aliases
         } catch (e: Exception) {
-            logd(TAG, "Error diagnosing Android Keystore: ${e.message}")
+            loge(TAG, "Error diagnosing Android Keystore: ${e.message}")
             emptyList()
         }
     }
 
+    /**
+     * Discovers recoverable legacy aliases for locally known addresses without mutating caches.
+     * Every invocation performs a fresh scan so partial failures never suppress a later retry.
+     */
+    suspend fun discoverOrphanedKeystoreKeys(
+        knownAddresses: Set<String> = collectKnownAddresses(),
+    ): RecoveryDiscovery {
+        val keystore = try {
+            androidKeystoreSource()
+        } catch (e: Exception) {
+            return RecoveryDiscovery(
+                matches = emptyList(),
+                failures = listOf(
+                    RecoveryFailure("AndroidKeyStore", e.message ?: e.javaClass.simpleName)
+                ),
+                isComplete = false,
+            )
+        }
+
+        return discoverOrphanedKeystoreKeys(
+            knownAddresses = knownAddresses,
+            aliasPrefix = KeyManager.KEYSTORE_ALIAS_PREFIX,
+            keystore = keystore,
+            onChainKeys = OnChainKeySource { address ->
+                FlowCadenceApi.getAccount(address).keys.orEmpty().map { key ->
+                    OnChainKey(publicKey = key.publicKey, revoked = key.revoked)
+                }
+            },
+        )
+    }
+
+    internal suspend fun discoverOrphanedKeystoreKeys(
+        knownAddresses: Set<String>,
+        aliasPrefix: String,
+        keystore: LegacyKeystoreSource,
+        onChainKeys: OnChainKeySource,
+    ): RecoveryDiscovery {
+        val failures = mutableListOf<RecoveryFailure>()
+        val aliases = try {
+            filterLegacyAliases(keystore.aliases(), aliasPrefix)
+        } catch (e: Exception) {
+            return RecoveryDiscovery(
+                matches = emptyList(),
+                failures = listOf(
+                    RecoveryFailure("AndroidKeyStore", e.message ?: e.javaClass.simpleName)
+                ),
+                isComplete = false,
+            )
+        }
+
+        val addressesByPublicKey = mutableMapOf<String, MutableSet<String>>()
+        knownAddresses.distinctBy(::normalizeAddress).forEach { address ->
+            try {
+                onChainKeys.keys(address)
+                    .asSequence()
+                    .filterNot { it.revoked }
+                    .forEach { key ->
+                        val normalized = normalizePublicKey(key.publicKey)
+                        if (normalized == null) {
+                            failures += RecoveryFailure(
+                                target = address,
+                                message = "Invalid on-chain public key",
+                            )
+                        } else {
+                            addressesByPublicKey.getOrPut(normalized) { linkedSetOf() }
+                                .add(address)
+                        }
+                    }
+            } catch (e: Exception) {
+                failures += RecoveryFailure(address, e.message ?: e.javaClass.simpleName)
+            }
+        }
+
+        val matches = mutableListOf<RecoveryMatch>()
+        aliases.forEach { alias ->
+            val publicKey = try {
+                keystore.publicKey(alias)?.let(::flowPublicKey)
+            } catch (e: Exception) {
+                failures += RecoveryFailure(alias, e.message ?: e.javaClass.simpleName)
+                null
+            }
+
+            if (publicKey == null) {
+                if (failures.none { it.target == alias }) {
+                    failures += RecoveryFailure(alias, "Missing or invalid EC certificate public key")
+                }
+                return@forEach
+            }
+
+            addressesByPublicKey[publicKey].orEmpty().forEach { address ->
+                matches += RecoveryMatch(
+                    prefix = alias.removePrefix(aliasPrefix),
+                    address = address,
+                    publicKey = publicKey,
+                )
+            }
+        }
+
+        return RecoveryDiscovery(
+            matches = matches.distinctBy { Triple(it.prefix, normalizeAddress(it.address), it.publicKey) },
+            failures = failures,
+            isComplete = failures.isEmpty(),
+        )
+    }
+
+    internal fun filterLegacyAliases(aliases: List<String>, aliasPrefix: String): List<String> {
+        return aliases.filter { alias ->
+            alias.startsWith(aliasPrefix) && alias.length > aliasPrefix.length
+        }
+    }
+
+    internal fun androidKeystoreSource(): LegacyKeystoreSource {
+        return AndroidLegacyKeystoreSource()
+    }
+
+    /**
+     * Normalizes Flow's 128-character x||y form and SEC1's 130-character 04||x||y form.
+     * A valid 128-character Flow key that naturally starts with 04 is left intact.
+     */
+    internal fun normalizePublicKey(publicKey: String): String? {
+        val withoutHexPrefix = publicKey.trim().let { value ->
+            if (value.startsWith("0x", ignoreCase = true)) value.substring(2) else value
+        }
+        val normalized = if (
+            withoutHexPrefix.length == 130 &&
+            withoutHexPrefix.startsWith("04", ignoreCase = true)
+        ) {
+            withoutHexPrefix.substring(2)
+        } else {
+            withoutHexPrefix
+        }
+
+        return normalized.lowercase().takeIf { value ->
+            value.length == 128 && value.all { it in '0'..'9' || it in 'a'..'f' }
+        }
+    }
+
+    internal fun flowPublicKey(publicKey: ECPublicKey): String? {
+        val x = paddedCoordinate(publicKey.w.affineX.toByteArray()) ?: return null
+        val y = paddedCoordinate(publicKey.w.affineY.toByteArray()) ?: return null
+        return (x + y).joinToString(separator = "") { byte ->
+            "%02x".format(byte.toInt() and 0xff)
+        }
+    }
+
+    private fun paddedCoordinate(bytes: ByteArray): ByteArray? {
+        val unsigned = when {
+            bytes.size == 33 && bytes.first() == 0.toByte() -> bytes.copyOfRange(1, bytes.size)
+            bytes.size <= 32 -> bytes
+            else -> return null
+        }
+        return ByteArray(32).also { padded ->
+            unsigned.copyInto(padded, destinationOffset = padded.size - unsigned.size)
+        }
+    }
+
+    internal fun normalizeAddress(address: String): String {
+        return if (address.startsWith("0x", ignoreCase = true)) {
+            address.substring(2).lowercase()
+        } else {
+            address.lowercase()
+        }
+    }
+
+    internal fun locallyKnownFlowAddresses(
+        account: Account,
+        network: String = chainNetWorkString(),
+    ): Set<String> {
+        val nodeAddresses = account.walletNodes
+            .filterIsInstance<FlowWallet>()
+            .filter { it.chainIdString.equals(network, ignoreCase = true) }
+            .map { it.address }
+        val cachedAddresses = account.wallet?.wallets.orEmpty()
+            .flatMap { it.blockchain.orEmpty() }
+            .filter { it.chainId.isBlank() || it.chainId.equals(network, ignoreCase = true) }
+            .map { it.address }
+        return (nodeAddresses + cachedAddresses).filterTo(linkedSetOf()) { it.isNotBlank() }
+    }
+
+    private fun collectKnownAddresses(): Set<String> {
+        return AccountManager.list().flatMapTo(linkedSetOf()) { account ->
+            locallyKnownFlowAddresses(account)
+        }
+    }
+
+    private class AndroidLegacyKeystoreSource : LegacyKeystoreSource {
+        private val keyStore = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+
+        override fun aliases(): List<String> {
+            val aliases = mutableListOf<String>()
+            val entries = keyStore.aliases()
+            while (entries.hasMoreElements()) {
+                aliases += entries.nextElement()
+            }
+            return aliases
+        }
+
+        override fun publicKey(alias: String): ECPublicKey? {
+            return keyStore.getCertificate(alias)?.publicKey as? ECPublicKey
+        }
+    }
 }

--- a/app/src/test/java/com/flowfoundation/wallet/manager/account/AccountManagerRecoveryTest.kt
+++ b/app/src/test/java/com/flowfoundation/wallet/manager/account/AccountManagerRecoveryTest.kt
@@ -1,0 +1,281 @@
+package com.flowfoundation.wallet.manager.account
+
+import com.flowfoundation.wallet.cache.AccountCacheManager
+import com.flowfoundation.wallet.cache.UserPrefixCacheManager
+import com.flowfoundation.wallet.manager.app.chainNetWorkString
+import com.flowfoundation.wallet.manager.walletdata.FlowWallet
+import com.flowfoundation.wallet.network.model.BlockchainData
+import com.flowfoundation.wallet.network.model.UserInfoData
+import com.flowfoundation.wallet.network.model.WalletData
+import com.flowfoundation.wallet.network.model.WalletListData
+import io.mockk.every
+import io.mockk.firstArg
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class AccountManagerRecoveryTest {
+    private val accountSnapshots = mutableListOf<List<Account>>()
+    private val prefixSnapshots = mutableListOf<List<UserPrefix>>()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        mockkObject(AccountCacheManager, UserPrefixCacheManager)
+        every { AccountCacheManager.cache(any()) } answers {
+            accountSnapshots += firstArg<List<Account>>().toList()
+        }
+        every { UserPrefixCacheManager.cache(any()) } answers {
+            prefixSnapshots += firstArg<List<UserPrefix>>().toList()
+        }
+        resetAccountManager()
+    }
+
+    @After
+    fun tearDown() {
+        resetAccountManager()
+        unmockkAll()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `publishes accumulated recovery while preserving real account identities`() {
+        val alice = account(
+            uid = "uid-alice",
+            username = "alice",
+            avatar = "alice.png",
+            address = "0x01",
+            prefix = null,
+            active = true,
+        )
+        val bob = account(
+            uid = "uid-bob",
+            username = "bob",
+            avatar = "bob.png",
+            address = "0x02",
+            prefix = "beta",
+            active = false,
+        )
+        seedAccountManager(
+            accounts = listOf(alice, bob),
+            prefixes = listOf(UserPrefix("uid-alice", "stale-prefix")),
+        )
+        val publishedLists = mutableListOf<List<Account>>()
+        val publishedAccounts = mutableListOf<Account>()
+        val accountListener = object : OnAccountUpdate {
+            override fun onAccountUpdate(account: Account) {
+                publishedAccounts += account
+            }
+        }
+        val listener = object : OnAccountListUpdate {
+            override fun onAccountListUpdate(accounts: List<Account>) {
+                publishedLists += accounts.toList()
+            }
+        }
+        AccountManager.addListener(accountListener)
+        AccountManager.addAccountListUpdateListener(listener)
+
+        val publication = AccountManager.applyRecoveredKeystoreKeys(
+            listOf(
+                recovery("alpha", "0x01"),
+                recovery("beta", "0x02"),
+            )
+        )
+
+        assertThat(publication.updatedAccountCount).isEqualTo(2)
+        assertThat(publication.unresolvedMatches).isEmpty()
+        assertThat(AccountManager.list()).hasSize(2)
+
+        val recoveredAlice = AccountManager.list().single { it.wallet?.id == "uid-alice" }
+        val recoveredBob = AccountManager.list().single { it.wallet?.id == "uid-bob" }
+        assertThat(recoveredAlice).isEqualTo(alice.copy(prefix = "alpha"))
+        assertThat(recoveredBob).isEqualTo(bob)
+        assertThat(recoveredAlice.userInfo.username).isEqualTo("alice")
+        assertThat(recoveredAlice.userInfo.avatar).isEqualTo("alice.png")
+        assertThat(recoveredAlice.walletNodes).isEqualTo(alice.walletNodes)
+
+        assertThat(accountSnapshots).containsExactly(AccountManager.list())
+        assertThat(prefixSnapshots).containsExactly(
+            listOf(
+                UserPrefix("uid-alice", "alpha"),
+                UserPrefix("uid-bob", "beta"),
+            )
+        )
+        assertThat(publishedAccounts).containsExactly(recoveredAlice)
+        assertThat(publishedLists).hasSize(1)
+        assertThat(publishedLists.single()).isEqualTo(AccountManager.list())
+        verify(exactly = 1) { AccountCacheManager.cache(any()) }
+        verify(exactly = 1) { UserPrefixCacheManager.cache(any()) }
+    }
+
+    @Test
+    fun `repeated recovery is idempotent and wallet UID stays switcher resolvable`() {
+        val account = account(
+            uid = "real-wallet-uid",
+            username = "real-user",
+            avatar = "avatar.png",
+            address = "0x0a",
+            prefix = null,
+            active = true,
+        )
+        seedAccountManager(listOf(account), emptyList())
+        val match = recovery("recovered-prefix", "0x0a")
+
+        val first = AccountManager.applyRecoveredKeystoreKeys(listOf(match))
+        val second = AccountManager.applyRecoveredKeystoreKeys(listOf(match))
+
+        assertThat(first.updatedAccountCount).isEqualTo(1)
+        assertThat(second.updatedAccountCount).isZero()
+        assertThat(AccountManager.list()).hasSize(1)
+        val switcherAccount = AccountManager.getSwitchAccountList()
+            .filterIsInstance<Account>()
+            .single { it.wallet?.id == "real-wallet-uid" }
+        assertThat(switcherAccount.userInfo.username).isEqualTo("real-user")
+        assertThat(switcherAccount.prefix).isEqualTo("recovered-prefix")
+        assertThat(prefixSnapshots.single()).containsExactly(
+            UserPrefix("real-wallet-uid", "recovered-prefix")
+        )
+        assertThat(accountSnapshots).hasSize(1)
+        assertThat(prefixSnapshots).hasSize(1)
+        verify(exactly = 1) { AccountCacheManager.cache(any()) }
+        verify(exactly = 1) { UserPrefixCacheManager.cache(any()) }
+    }
+
+    @Test
+    fun `ambiguous prefixes do not replace a real account`() {
+        val account = account(
+            uid = "uid-alice",
+            username = "alice",
+            avatar = "alice.png",
+            address = "0x01",
+            prefix = null,
+            active = true,
+        )
+        seedAccountManager(listOf(account), emptyList())
+        val matches = listOf(
+            recovery("alpha", "0x01"),
+            recovery("beta", "0x01"),
+        )
+
+        val publication = AccountManager.applyRecoveredKeystoreKeys(matches)
+
+        assertThat(publication.updatedAccountCount).isZero()
+        assertThat(publication.unresolvedMatches).containsExactlyInAnyOrderElementsOf(matches)
+        assertThat(AccountManager.list()).containsExactly(account)
+        verify(exactly = 0) { AccountCacheManager.cache(any()) }
+        verify(exactly = 0) { UserPrefixCacheManager.cache(any()) }
+    }
+
+    @Test
+    fun `wallet refresh cannot overwrite a recovered prefix`() {
+        val account = account(
+            uid = "uid-alice",
+            username = "alice",
+            avatar = "alice.png",
+            address = "0x01",
+            prefix = null,
+            active = true,
+        )
+        seedAccountManager(listOf(account), emptyList())
+        AccountManager.applyRecoveredKeystoreKeys(listOf(recovery("alpha", "0x01")))
+
+        AccountManager.updateAccountList(listOf(account.copy(prefix = null)))
+
+        assertThat(AccountManager.list().single().prefix).isEqualTo("alpha")
+    }
+
+    private fun account(
+        uid: String,
+        username: String,
+        avatar: String,
+        address: String,
+        prefix: String?,
+        active: Boolean,
+    ): Account {
+        return Account(
+            userInfo = UserInfoData(
+                username = username,
+                nickname = username,
+                avatar = avatar,
+                created = "1",
+            ),
+            isActive = active,
+            wallet = WalletListData(
+                id = uid,
+                username = username,
+                wallets = listOf(
+                    WalletData(
+                        name = "Flow",
+                        blockchain = listOf(BlockchainData(address, chainNetWorkString())),
+                    )
+                ),
+            ),
+            prefix = prefix,
+            walletNodes = listOf(
+                FlowWallet(
+                    address,
+                    "Flow",
+                    emojiId = 1,
+                    chainIdString = chainNetWorkString(),
+                )
+            ),
+        )
+    }
+
+    private fun recovery(
+        prefix: String,
+        address: String,
+    ): KeyStoreMigrationManager.RecoveryMatch {
+        return KeyStoreMigrationManager.RecoveryMatch(
+            prefix = prefix,
+            address = address,
+            publicKey = "ab".repeat(64),
+        )
+    }
+
+    private fun seedAccountManager(
+        accounts: List<Account>,
+        prefixes: List<UserPrefix>,
+    ) {
+        mutableListField<Account>("accounts").apply {
+            clear()
+            addAll(accounts)
+        }
+        mutableListField<UserPrefix>("userPrefixes").apply {
+            clear()
+            addAll(prefixes)
+        }
+        currentAccountField().set(AccountManager, accounts.firstOrNull { it.isActive })
+    }
+
+    private fun resetAccountManager() {
+        mutableListField<Account>("accounts").clear()
+        mutableListField<UserPrefix>("userPrefixes").clear()
+        mutableListField<Any>("listeners").clear()
+        mutableListField<Any>("listListeners").clear()
+        currentAccountField().set(AccountManager, null)
+        accountSnapshots.clear()
+        prefixSnapshots.clear()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> mutableListField(name: String): MutableList<T> {
+        val field = AccountManager::class.java.getDeclaredField(name).apply {
+            isAccessible = true
+        }
+        return field.get(AccountManager) as MutableList<T>
+    }
+
+    private fun currentAccountField() =
+        AccountManager::class.java.getDeclaredField("currentAccount").apply {
+            isAccessible = true
+        }
+}

--- a/app/src/test/java/com/flowfoundation/wallet/manager/account/KeyStoreMigrationManagerTest.kt
+++ b/app/src/test/java/com/flowfoundation/wallet/manager/account/KeyStoreMigrationManagerTest.kt
@@ -1,0 +1,181 @@
+package com.flowfoundation.wallet.manager.account
+
+import java.math.BigInteger
+import java.security.interfaces.ECPublicKey
+import java.security.spec.ECParameterSpec
+import java.security.spec.ECPoint
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class KeyStoreMigrationManagerTest {
+
+    @Test
+    fun `normalizes Flow and SEC1 public keys without truncating Flow keys`() {
+        val flowKeyBeginningWith04 = "04" + "ab".repeat(63)
+        val sec1UncompressedKey = "04" + "cd".repeat(64)
+
+        assertThat(KeyStoreMigrationManager.normalizePublicKey(flowKeyBeginningWith04))
+            .isEqualTo(flowKeyBeginningWith04)
+        assertThat(KeyStoreMigrationManager.normalizePublicKey(sec1UncompressedKey))
+            .isEqualTo("cd".repeat(64))
+    }
+
+    @Test
+    fun `filters only non-empty legacy Flow aliases`() {
+        assertThat(
+            KeyStoreMigrationManager.filterLegacyAliases(
+                aliases = listOf(
+                    "unrelated",
+                    "user_keystore_",
+                    "user_keystore_alpha",
+                    "user_keystore_beta",
+                ),
+                aliasPrefix = "user_keystore_",
+            )
+        ).containsExactly("user_keystore_alpha", "user_keystore_beta")
+    }
+
+    @Test
+    fun `pads EC coordinates to 32 bytes`() {
+        val publicKey = FakeECPublicKey(BigInteger.ONE, BigInteger("80", 16))
+
+        assertThat(KeyStoreMigrationManager.flowPublicKey(publicKey)).isEqualTo(
+            "00".repeat(31) + "01" + "00".repeat(31) + "80"
+        )
+    }
+
+    @Test
+    fun `discovers multiple aliases and preserves one key to many addresses`() = runTest {
+        val keyA = FakeECPublicKey(BigInteger.ONE, BigInteger.TWO)
+        val keyB = FakeECPublicKey(BigInteger.valueOf(3), BigInteger.valueOf(4))
+        val flowKeyA = KeyStoreMigrationManager.flowPublicKey(keyA)!!
+        val flowKeyB = KeyStoreMigrationManager.flowPublicKey(keyB)!!
+        val keystore = FakeKeystore(
+            aliases = listOf("other", "legacy_alpha", "legacy_beta"),
+            publicKeys = mapOf("legacy_alpha" to keyA, "legacy_beta" to keyB),
+        )
+
+        val discovery = KeyStoreMigrationManager.discoverOrphanedKeystoreKeys(
+            knownAddresses = linkedSetOf("0x01", "0x02", "0x03"),
+            aliasPrefix = "legacy_",
+            keystore = keystore,
+            onChainKeys = KeyStoreMigrationManager.OnChainKeySource { address ->
+                when (address) {
+                    "0x01" -> listOf(
+                        KeyStoreMigrationManager.OnChainKey("04$flowKeyA", revoked = false)
+                    )
+                    "0x02" -> listOf(
+                        KeyStoreMigrationManager.OnChainKey(flowKeyA, revoked = false),
+                        KeyStoreMigrationManager.OnChainKey(flowKeyB, revoked = true),
+                    )
+                    else -> listOf(
+                        KeyStoreMigrationManager.OnChainKey(flowKeyB, revoked = false)
+                    )
+                }
+            },
+        )
+
+        assertThat(discovery.isComplete).isTrue()
+        assertThat(discovery.matches).containsExactlyInAnyOrder(
+            KeyStoreMigrationManager.RecoveryMatch("alpha", "0x01", flowKeyA),
+            KeyStoreMigrationManager.RecoveryMatch("alpha", "0x02", flowKeyA),
+            KeyStoreMigrationManager.RecoveryMatch("beta", "0x03", flowKeyB),
+        )
+    }
+
+    @Test
+    fun `partial failures are retried by the next discovery`() = runTest {
+        val key = FakeECPublicKey(BigInteger.TEN, BigInteger.valueOf(11))
+        val flowKey = KeyStoreMigrationManager.flowPublicKey(key)!!
+        val keystore = FakeKeystore(
+            aliases = listOf("legacy_alpha"),
+            publicKeys = mapOf("legacy_alpha" to key),
+        )
+        var shouldFail = true
+        val source = KeyStoreMigrationManager.OnChainKeySource {
+            if (shouldFail) error("offline")
+            listOf(KeyStoreMigrationManager.OnChainKey(flowKey, revoked = false))
+        }
+
+        val first = KeyStoreMigrationManager.discoverOrphanedKeystoreKeys(
+            knownAddresses = setOf("0x01"),
+            aliasPrefix = "legacy_",
+            keystore = keystore,
+            onChainKeys = source,
+        )
+        shouldFail = false
+        val second = KeyStoreMigrationManager.discoverOrphanedKeystoreKeys(
+            knownAddresses = setOf("0x01"),
+            aliasPrefix = "legacy_",
+            keystore = keystore,
+            onChainKeys = source,
+        )
+
+        assertThat(first.isComplete).isFalse()
+        assertThat(first.failures.single().message).isEqualTo("offline")
+        assertThat(second.isComplete).isTrue()
+        assertThat(second.matches).containsExactly(
+            KeyStoreMigrationManager.RecoveryMatch("alpha", "0x01", flowKey)
+        )
+    }
+
+    @Test
+    fun `certificate read failure is retried by the next discovery`() = runTest {
+        val key = FakeECPublicKey(BigInteger.valueOf(12), BigInteger.valueOf(13))
+        val flowKey = KeyStoreMigrationManager.flowPublicKey(key)!!
+        var shouldFail = true
+        val keystore = object : KeyStoreMigrationManager.LegacyKeystoreSource {
+            override fun aliases(): List<String> = listOf("legacy_alpha")
+
+            override fun publicKey(alias: String): ECPublicKey {
+                if (shouldFail) error("certificate unavailable")
+                return key
+            }
+        }
+        val source = KeyStoreMigrationManager.OnChainKeySource {
+            listOf(KeyStoreMigrationManager.OnChainKey(flowKey, revoked = false))
+        }
+
+        val first = KeyStoreMigrationManager.discoverOrphanedKeystoreKeys(
+            knownAddresses = setOf("0x01"),
+            aliasPrefix = "legacy_",
+            keystore = keystore,
+            onChainKeys = source,
+        )
+        shouldFail = false
+        val second = KeyStoreMigrationManager.discoverOrphanedKeystoreKeys(
+            knownAddresses = setOf("0x01"),
+            aliasPrefix = "legacy_",
+            keystore = keystore,
+            onChainKeys = source,
+        )
+
+        assertThat(first.isComplete).isFalse()
+        assertThat(first.failures.single().message).isEqualTo("certificate unavailable")
+        assertThat(second.isComplete).isTrue()
+        assertThat(second.matches).hasSize(1)
+    }
+
+    private class FakeKeystore(
+        private val aliases: List<String>,
+        private val publicKeys: Map<String, ECPublicKey>,
+    ) : KeyStoreMigrationManager.LegacyKeystoreSource {
+        override fun aliases(): List<String> = aliases
+
+        override fun publicKey(alias: String): ECPublicKey? = publicKeys[alias]
+    }
+
+    private class FakeECPublicKey(
+        x: BigInteger,
+        y: BigInteger,
+    ) : ECPublicKey {
+        private val point = ECPoint(x, y)
+
+        override fun getW(): ECPoint = point
+        override fun getParams(): ECParameterSpec? = null
+        override fun getAlgorithm(): String = "EC"
+        override fun getFormat(): String = "X.509"
+        override fun getEncoded(): ByteArray = byteArrayOf()
+    }
+}


### PR DESCRIPTION
## Summary

Recover legacy Flow accounts whose Android Keystore key still exists but whose
local prefix mapping was lost.

- Discover legacy Keystore aliases and normalize their EC public keys.
- Match non-revoked keys against Flow addresses already known locally.
- Restore the recovered prefix onto the existing real account.
- Repair the wallet UID-to-prefix mapping and publish the updated account list.
- Retry naturally after partial network or certificate failures.

The scanner does not mutate caches, and recovery does not create synthetic accounts or identities.

## Scope

This PR contains Android Keystore recovery only. Key-rotation WAL, mnemonic staging, staged signing, commit/finalize/discard APIs, algorithm metadata, and bridge compatibility remain outside this PR. NativeFRWBridge.kt is unchanged.

## Tests

Focused JVM coverage for normalization, discovery, partial failures, accumulated persistence, identity preservation, publication, switching identity, partial state repair, and idempotence, plus Android Keystore instrumentation coverage.

## Validation status

I added focused JVM and Android Keystore instrumentation tests, but I have not been able to compile or execute them locally because the required Flow GitHub Packages dependencies return 401 Unauthorized. This repository does not appear to run Android compilation or tests on pull requests, so the rebuilt branch still needs validation in an authenticated maintainer environment before merge.

## Limitation

Recovery is intentionally limited to accounts whose Flow addresses remain available in local account state. It does not perform global public-key-to-address discovery. Ambiguous cases where multiple Keystore aliases could restore the same account are preserved for retry/manual handling rather than guessed automatically.